### PR TITLE
Feature/db schema

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,32 @@
+# Dockerfile.dev
+FROM ruby:3.3.5-slim
+
+# 必要なパッケージをインストール
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    libpq-dev \
+    libvips \
+    postgresql-client \
+    curl \
+    vim \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# 作業ディレクトリを設定
+WORKDIR /rails
+
+# GemfileとGemfile.lockをコピー
+COPY Gemfile Gemfile.lock ./
+
+# Bundlerをインストールしてgemをインストール
+RUN bundle install
+
+# アプリケーションのコードをコピー
+COPY . .
+
+# ポート3000を公開
+EXPOSE 3000
+
+# サーバーを起動
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,0 +1,2 @@
+class Station < ApplicationRecord
+end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,2 +1,13 @@
 class Station < ApplicationRecord
+  has_many :toilets, dependent: :destroy
+
+  validates :name, presence: true
+  validates :operator_name, presence: true
+  validates :latitude, presence: true
+  validates :longitude, presence: true
+
+  validates :name, uniqueness: { scope: :operator_name }
+  def display_name
+    "#{operator_name} #{name}"
+  end
 end

--- a/app/models/toilet.rb
+++ b/app/models/toilet.rb
@@ -1,0 +1,9 @@
+class Toilet < ApplicationRecord
+  belongs_to :station
+
+  enum :style_type, { japanese: 0, western: 1, both: 2 }
+
+  validates :name, presence: true
+  validates :latitude, presence: true
+  validates :longitude, presence: true
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,15 +18,11 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  port: 5432
-  host: localhost
-  username: postgres
-  password: password
-
 
 development:
   <<: *default
-  database: toilet_navi_development
+  # DATABASE_URL環境変数を優先的に使用
+  url: <%= ENV['DATABASE_URL'] %>
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -61,6 +57,10 @@ development:
 test:
   <<: *default
   database: toilet_navi_test
+  host: db
+  username: postgres
+  password: password
+  post: 5432
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20260124132610_create_stations.rb
+++ b/db/migrate/20260124132610_create_stations.rb
@@ -1,0 +1,12 @@
+class CreateStations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :stations do |t|
+      t.string :name
+      t.string :operator_name
+      t.decimal :latitude
+      t.decimal :longitude
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260125072806_create_stations.rb
+++ b/db/migrate/20260125072806_create_stations.rb
@@ -1,10 +1,10 @@
 class CreateStations < ActiveRecord::Migration[8.0]
   def change
     create_table :stations do |t|
-      t.string :name
+      t.string :name, null: false
       t.string :operator_name
-      t.decimal :latitude
-      t.decimal :longitude
+      t.decimal :latitude, precision: 10, scale: 7, null: false
+      t.decimal :longitude, precision: 10, scale: 7, null: false
 
       t.timestamps
     end

--- a/db/migrate/20260125080928_create_toilets.rb
+++ b/db/migrate/20260125080928_create_toilets.rb
@@ -1,0 +1,20 @@
+class CreateToilets < ActiveRecord::Migration[8.0]
+  def change
+    create_table :toilets do |t|
+      t.references :station, null: false, foreign_key: true
+      t.string :name
+      t.decimal :latitude, precision: 10, scale: 7
+      t.decimal :longitude, precision: 10, scale: 7
+      t.text :location_note
+      t.boolean :is_wheelchair_accessible
+      t.boolean :is_ostomate_accessible
+      t.boolean :is_baby_friendly
+      t.boolean :is_gender_separated
+      t.boolean :is_multipurpose
+      t.integer :style_type
+      t.string :place_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260125132510_change_stations_lat_lng_precision.rb
+++ b/db/migrate/20260125132510_change_stations_lat_lng_precision.rb
@@ -1,0 +1,6 @@
+class ChangeStationsLatLngPrecision < ActiveRecord::Migration[8.0]
+  def change
+    change_column :stations, :latitude,  :decimal, precision: 10, scale: 7
+    change_column :stations, :longitude, :decimal, precision: 10, scale: 7
+  end
+end

--- a/db/migrate/20260126083737_add_defaults_and_null_constraints_to_toilets.rb
+++ b/db/migrate/20260126083737_add_defaults_and_null_constraints_to_toilets.rb
@@ -1,0 +1,42 @@
+class AddDefaultsAndNullConstraintsToToilets < ActiveRecord::Migration[8.0]
+  def change
+    # boolean は nil を許すと表示側が面倒なので、false で統一する
+    change_column_default :toilets, :is_wheelchair_accessible, from: nil, to: false
+    change_column_default :toilets, :is_ostomate_accessible,   from: nil, to: false
+    change_column_default :toilets, :is_baby_friendly,         from: nil, to: false
+    change_column_default :toilets, :is_gender_separated,      from: nil, to: false
+    change_column_default :toilets, :is_multipurpose,          from: nil, to: false
+
+    # 既存レコードの nil を埋める（既に作ったテストデータがある前提）
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE toilets
+          SET
+            is_wheelchair_accessible = COALESCE(is_wheelchair_accessible, FALSE),
+            is_ostomate_accessible   = COALESCE(is_ostomate_accessible,   FALSE),
+            is_baby_friendly         = COALESCE(is_baby_friendly,         FALSE),
+            is_gender_separated      = COALESCE(is_gender_separated,      FALSE),
+            is_multipurpose          = COALESCE(is_multipurpose,          FALSE)
+        SQL
+
+        # style_type（enum）も nil を許すと扱いづらいので、両方併設(both)をデフォルトにする
+        execute <<~SQL
+          UPDATE toilets
+          SET style_type = COALESCE(style_type, 2)
+        SQL
+      end
+    end
+
+    # null 制約をつける
+    change_column_null :toilets, :is_wheelchair_accessible, false
+    change_column_null :toilets, :is_ostomate_accessible,   false
+    change_column_null :toilets, :is_baby_friendly,         false
+    change_column_null :toilets, :is_gender_separated,      false
+    change_column_null :toilets, :is_multipurpose,          false
+
+    # enum のデフォルトと null 制約
+    change_column_default :toilets, :style_type, from: nil, to: 2
+    change_column_null    :toilets, :style_type, false
+  end
+end

--- a/db/migrate/20260126091416_add_constraints_to_toilets.rb
+++ b/db/migrate/20260126091416_add_constraints_to_toilets.rb
@@ -1,0 +1,26 @@
+class AddConstraintsToToilets < ActiveRecord::Migration[8.0]
+  def change
+    # まずは既存データが nil の場合に備えて埋める（将来の事故防止）
+    change_column_default :toilets, :is_wheelchair_accessible, from: nil, to: false
+    change_column_default :toilets, :is_ostomate_accessible,   from: nil, to: false
+    change_column_default :toilets, :is_baby_friendly,         from: nil, to: false
+    change_column_default :toilets, :is_gender_separated,      from: nil, to: false
+    change_column_default :toilets, :is_multipurpose,          from: nil, to: false
+
+    # style_type は enum なので default を入れておく（both=2 の想定）
+    change_column_default :toilets, :style_type, from: nil, to: 2
+
+    # nil を禁止（MVPの地図表示に必須）
+    change_column_null :toilets, :name,      false
+    change_column_null :toilets, :latitude,  false
+    change_column_null :toilets, :longitude, false
+
+    change_column_null :toilets, :is_wheelchair_accessible, false
+    change_column_null :toilets, :is_ostomate_accessible,   false
+    change_column_null :toilets, :is_baby_friendly,         false
+    change_column_null :toilets, :is_gender_separated,      false
+    change_column_null :toilets, :is_multipurpose,          false
+
+    change_column_null :toilets, :style_type, false
+  end
+end

--- a/db/migrate/20260126111013_test_toilets_default.rb
+++ b/db/migrate/20260126111013_test_toilets_default.rb
@@ -1,0 +1,5 @@
+class TestToiletsDefault < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :toilets, :style_type, from: nil, to: 2
+  end
+end

--- a/db/migrate/20260126111233_fix_toilets_constraints.rb
+++ b/db/migrate/20260126111233_fix_toilets_constraints.rb
@@ -1,0 +1,55 @@
+class FixToiletsConstraints < ActiveRecord::Migration[8.0]
+  def up
+    # 既存NULLを埋める（NOT NULL化で失敗しないため）
+    execute <<~SQL
+      UPDATE toilets SET is_wheelchair_accessible = FALSE WHERE is_wheelchair_accessible IS NULL;
+      UPDATE toilets SET is_ostomate_accessible   = FALSE WHERE is_ostomate_accessible   IS NULL;
+      UPDATE toilets SET is_baby_friendly         = FALSE WHERE is_baby_friendly         IS NULL;
+      UPDATE toilets SET is_gender_separated      = FALSE WHERE is_gender_separated      IS NULL;
+      UPDATE toilets SET is_multipurpose          = FALSE WHERE is_multipurpose          IS NULL;
+      UPDATE toilets SET style_type               = 2     WHERE style_type               IS NULL;
+    SQL
+
+    # DEFAULT（DB側に固定）
+    change_column_default :toilets, :is_wheelchair_accessible, from: nil, to: false
+    change_column_default :toilets, :is_ostomate_accessible,   from: nil, to: false
+    change_column_default :toilets, :is_baby_friendly,         from: nil, to: false
+    change_column_default :toilets, :is_gender_separated,      from: nil, to: false
+    change_column_default :toilets, :is_multipurpose,          from: nil, to: false
+    # style_type は既に default 2 が入ってるなら from: nil を外してもOK（厳密に行くなら後述）
+    change_column_default :toilets, :style_type, to: 2
+
+    # NOT NULL（DB側に固定）
+    change_column_null :toilets, :name,      false
+    change_column_null :toilets, :latitude,  false
+    change_column_null :toilets, :longitude, false
+
+    change_column_null :toilets, :is_wheelchair_accessible, false
+    change_column_null :toilets, :is_ostomate_accessible,   false
+    change_column_null :toilets, :is_baby_friendly,         false
+    change_column_null :toilets, :is_gender_separated,      false
+    change_column_null :toilets, :is_multipurpose,          false
+
+    change_column_null :toilets, :style_type, false
+  end
+
+  def down
+    change_column_null :toilets, :style_type, true
+    change_column_default :toilets, :style_type, from: 2, to: nil
+
+    %i[
+      is_wheelchair_accessible
+      is_ostomate_accessible
+      is_baby_friendly
+      is_gender_separated
+      is_multipurpose
+    ].each do |col|
+      change_column_null :toilets, col, true
+      change_column_default :toilets, col, from: false, to: nil
+    end
+
+    change_column_null :toilets, :longitude, true
+    change_column_null :toilets, :latitude,  true
+    change_column_null :toilets, :name,      true
+  end
+end

--- a/db/migrate/20260126111621_add_default_to_toilets_style_type.rb
+++ b/db/migrate/20260126111621_add_default_to_toilets_style_type.rb
@@ -1,0 +1,5 @@
+class AddDefaultToToiletsStyleType < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :toilets, :style_type, from: nil, to: 2
+  end
+end

--- a/db/migrate/20260126114538_fix_stations_constraints.rb
+++ b/db/migrate/20260126114538_fix_stations_constraints.rb
@@ -17,11 +17,11 @@ class FixStationsConstraints < ActiveRecord::Migration[8.0]
     change_column_null :stations, :longitude, false
 
     # --- 3) 重複防止（operator_name + name をユニーク） ---
-    add_index :stations, [:operator_name, :name], unique: true
+    add_index :stations, [ :operator_name, :name ], unique: true
   end
 
   def down
-    remove_index :stations, column: [:operator_name, :name]
+    remove_index :stations, column: [ :operator_name, :name ]
 
     change_column_null :stations, :longitude, true
     change_column_null :stations, :latitude, true

--- a/db/migrate/20260126114538_fix_stations_constraints.rb
+++ b/db/migrate/20260126114538_fix_stations_constraints.rb
@@ -1,0 +1,31 @@
+class FixStationsConstraints < ActiveRecord::Migration[8.0]
+  def up
+    # --- 1) 既存データの NULL を埋める ---
+    # （理由）NOT NULL 制約を付ける前に、DBエラーを防ぐため
+    execute <<~SQL
+      UPDATE stations SET operator_name = '不明' WHERE operator_name IS NULL;
+      UPDATE stations SET name = '不明' WHERE name IS NULL;
+    SQL
+
+    # 緯度経度は仮値を入れず、もし NULL があれば明示的にエラーにした方が安全
+    # → ここでは NULL のまま残し、NOT NULL で migrate を落とす（問題の早期発見）
+
+    # --- 2) NOT NULL 制約 ---
+    change_column_null :stations, :operator_name, false
+    change_column_null :stations, :name, false
+    change_column_null :stations, :latitude, false
+    change_column_null :stations, :longitude, false
+
+    # --- 3) 重複防止（operator_name + name をユニーク） ---
+    add_index :stations, [:operator_name, :name], unique: true
+  end
+
+  def down
+    remove_index :stations, column: [:operator_name, :name]
+
+    change_column_null :stations, :longitude, true
+    change_column_null :stations, :latitude, true
+    change_column_null :stations, :name, true
+    change_column_null :stations, :operator_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_24_132610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "stations", force: :cascade do |t|
+    t.string "name"
+    t.string "operator_name"
+    t.decimal "latitude"
+    t.decimal "longitude"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_24_132610) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_26_114538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "stations", force: :cascade do |t|
-    t.string "name"
-    t.string "operator_name"
-    t.decimal "latitude"
-    t.decimal "longitude"
+    t.string "name", null: false
+    t.string "operator_name", null: false
+    t.decimal "latitude", precision: 10, scale: 7, null: false
+    t.decimal "longitude", precision: 10, scale: 7, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["operator_name", "name"], name: "index_stations_on_operator_name_and_name", unique: true
   end
+
+  create_table "toilets", force: :cascade do |t|
+    t.bigint "station_id", null: false
+    t.string "name", null: false
+    t.decimal "latitude", precision: 10, scale: 7, null: false
+    t.decimal "longitude", precision: 10, scale: 7, null: false
+    t.text "location_note"
+    t.boolean "is_wheelchair_accessible", default: false, null: false
+    t.boolean "is_ostomate_accessible", default: false, null: false
+    t.boolean "is_baby_friendly", default: false, null: false
+    t.boolean "is_gender_separated", default: false, null: false
+    t.boolean "is_multipurpose", default: false, null: false
+    t.integer "style_type", default: 2, null: false
+    t.string "place_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["station_id"], name: "index_toilets_on_station_id"
+  end
+
+  add_foreign_key "toilets", "stations"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,29 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0'"
+    volumes:
+      - .:/rails
+      - bundle_data:/usr/local/bundle
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:password@db:5432/toilet_navi_development
+      RAILS_ENV: development
 
 volumes:
   postgres_data:
+  bundle_data:


### PR DESCRIPTION
## 概要
MVP向けのデータベース構造（stations / toilets）を実装し、  
駅トイレ検索機能の基礎となるテーブル設計・制約・バリデーションを整備しました。

## 関連issue
Close #24 

## 変更内容
- stations / toilets テーブルの作成およびカラム定義
- toilets.station_id に外部キー制約を追加
- toilets の boolean カラムおよび style_type に NOT NULL / default 制約を追加
- stations の name / operator_name / latitude / longitude に NOT NULL 制約を追加
- stations に (operator_name, name) のユニーク制約を追加
- Station / Toilet モデルにバリデーションを追加
- Station モデルに表示用メソッド（display_name）を追加

## 確認方法
1. `docker compose run --rm web rails db:migrate` を実行
2. `rails console` または `rails runner` から Station / Toilet が作成できることを確認
3. `\d+ stations`, `\d+ toilets` にて DB 制約が反映されていることを確認

## スクリーンショット
なし（DB / バックエンド実装のみのため）

## セルフレビューチェックリスト
- [x] 不要なコードやコメントアウトが残っていないか
- [x] バリデーションは適切に設定されているか
- [x] 実装漏れがないか
