### PR TITLE
GoogleMap表示と現在地取得・トイレ一覧を実装

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.1)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.6)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -166,3 +166,55 @@
   }
 }
 
+/* --- Toilet list (Search page) --- */
+#toilet-list {
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.toilet-card {
+  padding: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  cursor: pointer;
+  background: #fff;
+}
+
+.toilet-card:hover {
+  background: #f7f7f7;
+}
+
+.toilet-card.is-selected {
+  background: #f2f6ff;
+  border-color: #b7ccff;
+}
+
+.toilet-card__title {
+  font-size: 12px;
+  opacity: 0.75;
+  margin-bottom: 6px;
+}
+
+.toilet-card__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.toilet-card__name {
+  font-weight: 600;
+}
+
+.toilet-card__icons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.facility-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,5 @@
 class SearchController < ApplicationController
   def new
+    @toilets = Toilet.includes(:station).limit(50)
   end
 end

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -16,11 +16,54 @@ function errorMessageFromGeolocationError(error) {
   return "位置情報の取得に失敗しました。";
 }
 
+let map; // グローバル保持
+let selectedToiletId = null;
+let toiletMarkersById = {};
+
+const FACILITY_ICON_DEFS = [
+  { key: "is_wheelchair_accessible", label: "車椅子", icon: "♿" },
+  { key: "is_ostomate_accessible", label: "オストメイト", icon: "🧻" }, // 仮
+  { key: "is_baby_friendly", label: "ベビー", icon: "👶" },
+  { key: "is_gender_separated", label: "男女別", icon: "🚻" },
+  { key: "is_multipurpose", label: "多目的", icon: "⭐" },
+];
+
+function buildFacilityIconsHtml(toilet) {
+  return FACILITY_ICON_DEFS
+    .filter((def) => toilet[def.key])
+    .map((def) => {
+      return `<span class="facility-icon" title="${escapeHtml(def.label)}">${def.icon}</span>`;
+    })
+    .join("");
+}
+
+
 function setupGeolocationButton() {
   const button = document.getElementById("get-location");
   const result = document.getElementById("location-result");
+  const mapElement = document.getElementById("map");
 
-  if (!button || !result) return;
+  if (!button || !result || !mapElement) return;
+
+  // ✅ Turbo再訪で多重登録されないように
+  if (button.dataset.geolocationBound === "true") return;
+  button.dataset.geolocationBound = "true";
+
+  const apiKey = mapElement.dataset.mapApiKeyValue;
+  const toiletsJson = mapElement.dataset.mapToiletsValue || "[]";
+  const toilets = JSON.parse(toiletsJson);
+
+  const modalClose = document.getElementById("toilet-modal-close");
+  const modalBackdrop = document.getElementById("toilet-modal-backdrop");
+
+  if (modalClose && modalClose.dataset.bound !== "true") {
+    modalClose.dataset.bound = "true";
+    modalClose.addEventListener("click", closeToiletModal);
+  }
+  if (modalBackdrop && modalBackdrop.dataset.bound !== "true") {
+    modalBackdrop.dataset.bound = "true";
+    modalBackdrop.addEventListener("click", closeToiletModal);
+  }
 
   button.addEventListener("click", () => {
     result.textContent = "";
@@ -40,6 +83,8 @@ function setupGeolocationButton() {
 
         result.textContent =
           `取得できました。緯度: ${lat.toFixed(6)}, 経度: ${lng.toFixed(6)}（精度: 約${Math.round(accuracy)}m）`;
+
+        loadGoogleMap(apiKey, lat, lng, toilets);
       },
       (error) => {
         result.textContent = errorMessageFromGeolocationError(error);
@@ -51,6 +96,207 @@ function setupGeolocationButton() {
       }
     );
   });
+}
+
+function loadGoogleMap(apiKey, lat, lng, toilets) {
+  if (window.google && window.google.maps && typeof window.google.maps.Map === "function") {
+    initMap(lat, lng, toilets);
+    return;
+  }
+
+  const existingScript = document.getElementById("google-maps-script");
+  if (existingScript) {
+    window.__initGoogleMap = () => initMap(lat, lng, toilets);
+    return;
+  }
+
+  window.__initGoogleMap = () => initMap(lat, lng, toilets);
+
+  const script = document.createElement("script");
+  script.id = "google-maps-script";
+
+  // 警告を減らす：loading=async を付与（callbackは維持）
+  script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&callback=__initGoogleMap&loading=async`;
+
+  script.async = true;
+  document.head.appendChild(script);
+}
+
+function initMap(lat, lng, toilets) {
+  map = new google.maps.Map(document.getElementById("map"), {
+    center: { lat, lng },
+    zoom: 12, // トイレが散らばっているので少し広めに（必要なら16に戻してOK）
+  });
+
+  // 現在地ピン（見分けやすく青）
+  const currentMarker = new google.maps.Marker({
+    position: { lat, lng },
+    map: map,
+    title: "現在地",
+    icon: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png",
+  });
+
+  // ✅ 現在地ピンもクリックで中心移動（あなたの意図どおり）
+  currentMarker.addListener("click", () => {
+    map.panTo(currentMarker.getPosition());
+    // ついでにズームも寄せたいなら↓（MVPなら好み）
+    // map.setZoom(16);
+  });
+
+  renderToiletMarkers(toilets);
+  renderToiletList(toilets);
+}
+
+/* --------------------
+   トイレのピン描画
+-------------------- */
+function renderToiletMarkers(toilets) {
+  toiletMarkersById = {};
+
+  toilets.forEach((toilet) => {
+    const marker = new google.maps.Marker({
+      position: {
+        lat: Number(toilet.latitude),
+        lng: Number(toilet.longitude),
+      },
+      map: map,
+      title: toilet.name,
+    });
+
+    toiletMarkersById[toilet.id] = marker;
+
+    marker.addListener("click", () => {
+      handleToiletSelect(toilet, {
+        lat: Number(toilet.latitude),
+        lng: Number(toilet.longitude),
+      });
+      // map.setZoom(16); // 寄せたいなら
+    });
+  });
+}
+
+/* --------------------
+   トイレ一覧描画（簡易）
+   - 運営会社名 + 駅名
+   - booleanはアイコン
+   - 選択状態ハイライト
+-------------------- */
+function renderToiletList(toilets) {
+  const list = document.getElementById("toilet-list");
+  if (!list) return;
+
+  list.innerHTML = "";
+
+  toilets.forEach((toilet) => {
+    const stationName = toilet.station?.name || "";
+    const operatorName = toilet.station?.operator_name || "";
+    const header = `${operatorName}${stationName ? " / " + stationName : ""}`;
+
+    const item = document.createElement("div");
+    item.className = "toilet-card";
+    item.dataset.toiletId = String(toilet.id);
+
+    item.innerHTML = `
+      <div class="toilet-card__title">${escapeHtml(header)}</div>
+      <div class="toilet-card__row">
+        <div class="toilet-card__name">${escapeHtml(toilet.name)}</div>
+        <div class="toilet-card__icons">${buildFacilityIconsHtml(toilet)}</div>
+      </div>
+    `;
+
+    item.addEventListener("click", () => {
+      handleToiletSelect(toilet, {
+        lat: Number(toilet.latitude),
+        lng: Number(toilet.longitude),
+      });
+    });
+
+
+    list.appendChild(item);
+  });
+
+  applySelectedStyle();
+}
+
+function selectToilet(toilet) {
+  selectedToiletId = toilet.id;
+  applySelectedStyle();
+  highlightSelectedMarker(toilet.id);
+}
+
+function applySelectedStyle() {
+  const list = document.getElementById("toilet-list");
+  if (!list) return;
+
+  Array.from(list.children).forEach((el) => {
+    const id = Number(el.dataset.toiletId);
+    if (id === selectedToiletId) {
+      el.classList.add("is-selected");
+    } else {
+      el.classList.remove("is-selected");
+    }
+  });
+}
+
+function highlightSelectedMarker(toiletId) {
+  Object.entries(toiletMarkersById).forEach(([id, marker]) => {
+    if (Number(id) === toiletId) {
+      marker.setIcon("http://maps.google.com/mapfiles/ms/icons/green-dot.png");
+    } else {
+      marker.setIcon(null);
+    }
+  });
+}
+
+// XSS対策（最低限）
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, (s) => {
+    const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+    return map[s];
+  });
+}
+
+function handleToiletSelect(toilet, panTargetLatLng) {
+  const isSameToilet = selectedToiletId === toilet.id;
+
+  // まずは選択状態を更新
+  selectToilet(toilet);
+
+  // 地図を中心へ
+  if (panTargetLatLng) {
+    map.panTo(panTargetLatLng);
+  }
+
+  // 同じトイレを「もう一度」選択したら詳細（モーダル）を開く
+  if (isSameToilet) {
+    openToiletModal(toilet);
+  }
+}
+
+function openToiletModal(toilet) {
+  const modal = document.getElementById("toilet-modal");
+  const modalBody = document.getElementById("toilet-modal-body");
+  if (!modal || !modalBody) {
+    // まだモーダルを作っていない場合に備えて落ちないように
+    return;
+  }
+
+  const stationName = toilet.station?.name || "";
+  const operatorName = toilet.station?.operator_name || "";
+  const header = `${operatorName}${stationName ? " / " + stationName : ""}`;
+
+  modalBody.innerHTML = `
+    <div class="modal__sub">${escapeHtml(header)}</div>
+    <div class="modal__title">${escapeHtml(toilet.name)}</div>
+  `;
+
+  modal.classList.add("is-open");
+}
+
+function closeToiletModal() {
+  const modal = document.getElementById("toilet-modal");
+  if (!modal) return;
+  modal.classList.remove("is-open");
 }
 
 document.addEventListener("turbo:load", setupGeolocationButton);

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -2,6 +2,20 @@
 
 <p>現在地から近いトイレを探します。</p>
 
-<button type="button" id="get-location" class="btn btn--primary">現在地を取得する</button>
+<button type="button" id="get-location" class="btn btn--primary">
+  現在地を取得する
+</button>
 
 <p id="location-result" style="margin-top: 12px;"></p>
+
+<div
+  id="map"
+  style="width: 100%; height: 60vh; margin-top: 16px; border-radius: 12px;"
+  data-map-api-key-value="<%= ENV.fetch('GOOGLE_MAPS_API_KEY', '') %>"
+  data-map-toilets-value="<%= @toilets.as_json(
+    only: [:id, :name, :latitude, :longitude, :is_wheelchair_accessible, :is_baby_friendly],
+    include: { station: { only: [:name, :operator_name] } }
+  ).to_json %>"
+></div>
+
+<div id="toilet-list" style="margin-top: 12px;"></div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,23 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+Station.where(operator_name: "JR東日本", name: "大宮駅").destroy_all
+
+station = Station.create!(
+  name: "大宮駅",
+  operator_name: "JR東日本",
+  latitude: 35.9066,
+  longitude: 139.6231
+)
+
+Toilet.where(station: station).destroy_all
+
+Toilet.create!(
+  station: station,
+  name: "テストトイレ",
+  latitude: 35.9069,
+  longitude: 139.6234,
+  is_wheelchair_accessible: true,
+  is_baby_friendly: true,
+  is_ostomate_accessible: false,
+  is_gender_separated: false,
+  is_multipurpose: false,
+  style_type: 2
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@db:5432/toilet_navi_development
       RAILS_ENV: development
+    env_file:
+      - .env
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## 概要
Google Maps を利用した現在地取得およびトイレ検索機能を実装しました。
現在地を起点として地図を表示し、周辺トイレをピンと一覧リストの両方で確認できるようにしています。

## 関連issue
Close #34 （Googlemap表示）

## 変更内容
- Geolocation API を用いた現在地取得機能の実装
- Google Maps API を利用した地図表示機能の追加
- 現在地ピンおよびトイレ位置ピンの表示
- トイレ一覧リストの表示
- トイレ選択時に地図中心が移動する連動機能の実装
- 選択中トイレのハイライト表示
- 現在地ピンとトイレピンの視認性向上（色分け）

## 確認方法
1. `/search` にアクセス
2. 「現在地を取得」ボタンをクリック
3. 地図上に現在地とトイレピンが表示されることを確認
4. トイレ一覧をクリックすると、地図の中心が該当トイレへ移動することを確認
5. 選択中のトイレがリスト上でハイライトされることを確認

## スクリーンショット
![GoogleMap表示](https://i.gyazo.com/7061e679d2d3751a4093dee5108ed7e3.png)


## セルフレビューチェックリスト
- [x] 不要なコードやコメントアウトが残っていないか
- [x] コンソールログやデバッグコードが残っていないか
- [x] エラーハンドリングは適切か
- [x] バリデーションは適切に設定されているか
- [x] 実装漏れがないか
