### PR TITLE
モーダル表示を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,6 +9,12 @@
  * Consider organizing styles into separate files for maintainability.
  */
 /* layout */
+#map {
+  width: 100%;
+  height: 320px; /* まずは固定でOK */
+  border-radius: 12px;
+}
+
 .site-header {
   position: sticky;
   top: 0;
@@ -213,8 +219,143 @@
   flex-wrap: wrap;
 }
 
+.toilet-card__detail {
+  border: 1px solid #e5e5e5;
+  background: #fff;
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  line-height: 30px;
+  font-size: 18px;
+}
+
+.toilet-card__detail:hover {
+  background: #f5f5f5;
+}
+
+.toilet-card__detail:active {
+  transform: translateY(1px);
+}
+
 .facility-icon {
   font-size: 18px;
   line-height: 1;
 }
 
+.toilet-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 1000;
+}
+
+.toilet-modal.is-open {
+  display: block;
+}
+
+.toilet-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: 0;
+}
+
+.toilet-modal__panel {
+  position: absolute;
+  left: 50%;
+  top: 10%;
+  transform: translateX(-50%);
+  width: min(92vw, 520px);
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  z-index: 1;
+}
+
+.toilet-modal__close {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  z-index: 2;
+}
+
+/* modal body (optional) */
+.toilet-modal__body {
+  display: grid;
+  gap: 10px;
+}
+
+.toilet-modal__sub {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.toilet-modal__title {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.toilet-modal__icons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.toilet-modal__titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.toilet-modal__fav {
+  border: 1px solid #e5e5e5;
+  background: #fff;
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.toilet-modal__photoPlaceholder {
+  height: 160px;
+  border-radius: 12px;
+  background: #f1f1f1;
+  display: grid;
+  place-items: center;
+  color: #666;
+}
+
+.toilet-modal__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.toilet-modal__cell {
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 10px 8px;
+  text-align: center;
+  background: #fff;
+  font-size: 13px;
+}
+
+.toilet-modal__sectionTitle {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.toilet-modal__placeholder {
+  background: #f1f1f1;
+  border-radius: 12px;
+  padding: 16px;
+  color: #666;
+}
+
+.toilet-modal__route {
+  width: 100%;
+  margin-top: 6px;
+}

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -65,6 +65,13 @@ function setupGeolocationButton() {
     modalBackdrop.addEventListener("click", closeToiletModal);
   }
 
+  if (document.documentElement.dataset.toiletModalEscBound !== "true") {
+    document.documentElement.dataset.toiletModalEscBound = "true";
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeToiletModal();
+    });
+  }
+
   button.addEventListener("click", () => {
     result.textContent = "";
 
@@ -199,18 +206,30 @@ function renderToiletList(toilets) {
     item.innerHTML = `
       <div class="toilet-card__title">${escapeHtml(header)}</div>
       <div class="toilet-card__row">
-        <div class="toilet-card__name">${escapeHtml(toilet.name)}</div>
-        <div class="toilet-card__icons">${buildFacilityIconsHtml(toilet)}</div>
+        <div>
+          <div class="toilet-card__name">${escapeHtml(toilet.name)}</div>
+          <div class="toilet-card__icons">${buildFacilityIconsHtml(toilet)}</div>
+        </div>
+
+        <button type="button" class="toilet-card__detail" aria-label="詳細を開く">
+          ›
+        </button>
       </div>
-    `;
+   `;
 
     item.addEventListener("click", () => {
-      handleToiletSelect(toilet, {
-        lat: Number(toilet.latitude),
-        lng: Number(toilet.longitude),
-      });
+      handleToiletSelect(toilet, { lat: Number(toilet.latitude), lng: Number(toilet.longitude) });
     });
 
+    const detailBtn = item.querySelector(".toilet-card__detail");
+    if (detailBtn) {
+      detailBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        selectToilet(toilet);
+        map.panTo({ lat: Number(toilet.latitude), lng: Number(toilet.longitude) });
+        openToiletModal(toilet);
+      });
+    }
 
     list.appendChild(item);
   });
@@ -219,9 +238,9 @@ function renderToiletList(toilets) {
 }
 
 function selectToilet(toilet) {
-  selectedToiletId = toilet.id;
+  selectedToiletId = Number(toilet.id);
   applySelectedStyle();
-  highlightSelectedMarker(toilet.id);
+  highlightSelectedMarker(selectedToiletId);
 }
 
 function applySelectedStyle() {
@@ -256,47 +275,212 @@ function escapeHtml(str) {
   });
 }
 
-function handleToiletSelect(toilet, panTargetLatLng) {
-  const isSameToilet = selectedToiletId === toilet.id;
+function markOrUnknown(value) {
+  if (value === true) return "〇";
+  if (value === false) return "×";
+  return "—"; // 未登録(null/undefined)用
+}
 
-  // まずは選択状態を更新
+function handleToiletSelect(toilet, panTargetLatLng) {
+  // 選択状態を更新
   selectToilet(toilet);
 
   // 地図を中心へ
   if (panTargetLatLng) {
     map.panTo(panTargetLatLng);
   }
+}
 
-  // 同じトイレを「もう一度」選択したら詳細（モーダル）を開く
-  if (isSameToilet) {
-    openToiletModal(toilet);
+function closeToiletModal() {
+  const modal = document.getElementById("toilet-modal");
+  if (!modal) return;
+
+  modal.classList.remove("is-open");
+  modal.setAttribute("aria-hidden", "true");
+}
+
+function setupToiletModalCloseEvents() {
+  const modalClose = document.getElementById("toilet-modal-close");
+  const modalBackdrop = document.getElementById("toilet-modal-backdrop");
+
+  if (modalClose && modalClose.dataset.bound !== "true") {
+    modalClose.dataset.bound = "true";
+    modalClose.addEventListener("click", closeToiletModal);
+  }
+
+  if (modalBackdrop && modalBackdrop.dataset.bound !== "true") {
+    modalBackdrop.dataset.bound = "true";
+    modalBackdrop.addEventListener("click", closeToiletModal);
+  }
+
+  if (document.documentElement.dataset.toiletModalEscBound !== "true") {
+    document.documentElement.dataset.toiletModalEscBound = "true";
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeToiletModal();
+    });
   }
 }
 
 function openToiletModal(toilet) {
   const modal = document.getElementById("toilet-modal");
   const modalBody = document.getElementById("toilet-modal-body");
-  if (!modal || !modalBody) {
-    // まだモーダルを作っていない場合に備えて落ちないように
-    return;
-  }
+  if (!modal || !modalBody) return;
 
   const stationName = toilet.station?.name || "";
   const operatorName = toilet.station?.operator_name || "";
   const header = `${operatorName}${stationName ? " / " + stationName : ""}`;
 
+  const styleText =
+    toilet.style_type === "japanese" ? "和式" :
+    toilet.style_type === "western" ? "洋式" :
+    toilet.style_type === "both" ? "併設" :
+    "不明";
+
+  const loggedIn = isLoggedIn();
+
+  // ✅ issue仕様：設備は「〇/×」で表示（男女別/共用、和式/洋式は文字）
+  const wheelchair = toilet.is_wheelchair_accessible ? "〇" : "×";
+  const ostomate   = toilet.is_ostomate_accessible ? "〇" : "×";
+  const baby       = toilet.is_baby_friendly ? "〇" : "×";
+
+  // 男女別 / 共用 は文字（issueの文言どおり）
+  const genderText = toilet.is_gender_separated ? "男女別" : "共用";
+
+  // ✅ issue仕様：Google Map ナビ用URL（緯度経度）
+  const lat = Number(toilet.latitude);
+  const lng = Number(toilet.longitude);
+  const canNavigate = Number.isFinite(lat) && Number.isFinite(lng);
+  const navUrl = canNavigate
+    ? `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=walking`
+    : "";
+
   modalBody.innerHTML = `
-    <div class="modal__sub">${escapeHtml(header)}</div>
-    <div class="modal__title">${escapeHtml(toilet.name)}</div>
+    <div class="toilet-modal__header">
+      <div>
+        <div class="toilet-modal__sub">${escapeHtml(header)}</div>
+        <div class="toilet-modal__titleRow">
+          <div class="toilet-modal__title">${escapeHtml(toilet.name || "名称未登録")}</div>
+
+          ${
+            loggedIn
+              ? `<button type="button" class="toilet-modal__fav" aria-label="お気に入り">☆</button>`
+              : `<button type="button" class="toilet-modal__favHint" aria-label="ログイン案内">☆</button>`
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="toilet-modal__photo">
+      <div class="toilet-modal__photoPlaceholder">写真表示エリア（MVPは後でOK）</div>
+    </div>
+
+    <!-- ✅ issue仕様：設備情報 -->
+    <div class="toilet-modal__section">
+      <div class="toilet-modal__sectionTitle">設備情報</div>
+
+      <div class="toilet-modal__grid">
+        <div class="toilet-modal__cell">
+          ウォシュレット：${markOrUnknown(toilet.has_washlet)}
+        </div>
+        <div class="toilet-modal__cell">
+          おむつ交換設備：${markOrUnknown(toilet.is_baby_friendly)}
+        </div>
+        <div class="toilet-modal__cell">
+          多目的トイレ：${markOrUnknown(toilet.is_multipurpose)}
+        </div>
+        <div class="toilet-modal__cell">
+          車いす対応：${markOrUnknown(toilet.is_wheelchair_accessible)}
+        </div>
+        <div class="toilet-modal__cell">
+          オストメイト対応：${markOrUnknown(toilet.is_ostomate_accessible)}
+        </div>
+        <div class="toilet-modal__cell">
+          男女別：${markOrUnknown(toilet.is_gender_separated)}
+        </div>
+      </div>
+    </div>
+
+    <div class="toilet-modal__section">
+      <div class="toilet-modal__sectionTitle">場所メモ</div>
+      <div class="toilet-modal__note">${escapeHtml(toilet.location_note || "（未登録）")}</div>
+    </div>
+
+    <div class="toilet-modal__section">
+      <div class="toilet-modal__sectionTitle">評価（将来）</div>
+      <div class="toilet-modal__placeholder">評価エリア（将来）</div>
+    </div>
+
+    <div class="toilet-modal__section">
+      <div class="toilet-modal__sectionTitle">コメント（将来）</div>
+      <div class="toilet-modal__placeholder">コメント表示（将来）</div>
+    </div>
+
+    <button
+      type="button"
+      class="btn btn--primary toilet-modal__route"
+      ${canNavigate ? "" : "disabled"}
+      data-nav-url="${escapeHtml(navUrl)}"
+    >
+      Google Mapで案内を開始する
+    </button>
   `;
 
+  bindToiletModalEvents(toilet);
+
   modal.classList.add("is-open");
+  modal.setAttribute("aria-hidden", "false");
 }
 
-function closeToiletModal() {
-  const modal = document.getElementById("toilet-modal");
-  if (!modal) return;
-  modal.classList.remove("is-open");
+
+function bindToiletModalEvents(toilet) {
+  const modalBody = document.getElementById("toilet-modal-body");
+  if (!modalBody) return;
+
+  // ☆（ログイン中）
+  const favBtn = modalBody.querySelector(".toilet-modal__fav");
+  if (favBtn) {
+    favBtn.onclick = () => {
+      console.log("お気に入り:", toilet.id);
+    };
+  }
+
+  // ☆（未ログイン：ログイン誘導）
+  const favHintBtn = modalBody.querySelector(".toilet-modal__favHint");
+  if (favHintBtn) {
+    favHintBtn.onclick = () => {
+      alert("お気に入り機能を使うにはログインが必要です");
+      // 将来：ログイン画面へ誘導するなら
+      // window.location.href = "/login";
+    };
+  }
+
+  // ルート案内（data-nav-url を優先）
+  const routeBtn = modalBody.querySelector(".toilet-modal__route");
+  if (routeBtn) {
+    routeBtn.onclick = () => {
+      const url = routeBtn.dataset.navUrl;
+      if (!url) return;
+      window.open(url, "_blank", "noopener,noreferrer");
+    };
+  }
 }
 
-document.addEventListener("turbo:load", setupGeolocationButton);
+function openRouteInGoogleMaps(toilet) {
+  const lat = Number(toilet.latitude);
+  const lng = Number(toilet.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+
+  // 現在地→目的地 のルート（Google Maps）
+  const url = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=walking`;
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+function isLoggedIn() {
+  const mapElement = document.getElementById("map");
+  return mapElement?.dataset.isLoggedInValue === "true";
+}
+
+document.addEventListener("turbo:load", () => {
+  setupGeolocationButton();
+  setupToiletModalCloseEvents();
+});

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -10,12 +10,30 @@
 
 <div
   id="map"
-  style="width: 100%; height: 60vh; margin-top: 16px; border-radius: 12px;"
+  data-is-logged-in-value="false"
   data-map-api-key-value="<%= ENV.fetch('GOOGLE_MAPS_API_KEY', '') %>"
   data-map-toilets-value="<%= @toilets.as_json(
-    only: [:id, :name, :latitude, :longitude, :is_wheelchair_accessible, :is_baby_friendly],
+    only: [
+      :id, :name, :latitude, :longitude,
+      :location_note, :style_type,
+      :is_wheelchair_accessible, :is_ostomate_accessible,
+      :is_baby_friendly, :is_gender_separated, :is_multipurpose
+    ],
     include: { station: { only: [:name, :operator_name] } }
   ).to_json %>"
 ></div>
 
 <div id="toilet-list" style="margin-top: 12px;"></div>
+
+<!-- ▼ トイレ詳細モーダル（JSで中身を差し替える） -->
+<div id="toilet-modal" class="toilet-modal" aria-hidden="true">
+  <div id="toilet-modal-backdrop" class="toilet-modal__backdrop"></div>
+
+  <div class="toilet-modal__panel" role="dialog" aria-modal="true" aria-label="トイレ詳細">
+    <button type="button" id="toilet-modal-close" class="toilet-modal__close" aria-label="閉じる">
+      ×
+    </button>
+
+    <div id="toilet-modal-body" class="toilet-modal__body"></div>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
- トイレ詳細をモーダル表示し、Google Mapで案内開始できるようにしました

## 関連issue
Close #36 

## 変更内容
- ピン/一覧からモーダルを開く
- 設備情報表示（バリアフリー/オストメイト/乳幼児/男女別/和式洋式）
- 目的地 から Google Maps URL を生成して起動
- モーダルの開閉（×/背景/ESC）

## 確認方法
- /search で現在地取得後、ピン/詳細ボタンでモーダル表示
- 案内ボタンでGoogle Mapsが目的地付きで開く

## スクリーンショット
[モーダル表示](https://i.gyazo.com/8bdcfa507c44b2042c34fdf11fbe7b39.png)

## セルフレビューチェックリスト
- [x] 不要なコードやコメントアウトが残っていないか
- [x] コンソールログやデバッグコードが残っていないか
- [x] 実装漏れがないか
