### PR TITLE
ローディング/0件表示の追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -359,3 +359,44 @@
   width: 100%;
   margin-top: 6px;
 }
+.search-status {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  background: #fff;
+  display: none; /* 使う時だけ表示 */
+}
+
+.search-status.is-show {
+  display: block;
+}
+
+.search-status.is-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.search-status__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ddd;
+  border-top-color: #111;
+  border-radius: 999px;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.search-status.is-error {
+  border-color: #ffd6d6;
+  background: #fff5f5;
+}
+
+.search-status.is-empty {
+  border-color: #eee;
+  background: #fafafa;
+}

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -50,8 +50,17 @@ function setupGeolocationButton() {
   button.dataset.geolocationBound = "true";
 
   const apiKey = mapElement.dataset.mapApiKeyValue;
-  const toiletsJson = mapElement.dataset.mapToiletsValue || "[]";
-  const toilets = JSON.parse(toiletsJson);
+  let toilets = [];
+  try {
+    const toiletsJson = mapElement.dataset.mapToiletsValue || "[]";
+    toilets = JSON.parse(toiletsJson);
+  } catch (e) {
+    toilets = [];
+    clearToiletList();
+    showErrorStatus("データの読み込みに失敗しました。ページを再読み込みしてください。");
+  }
+
+
 
   const modalClose = document.getElementById("toilet-modal-close");
   const modalBackdrop = document.getElementById("toilet-modal-backdrop");
@@ -74,13 +83,14 @@ function setupGeolocationButton() {
 
   button.addEventListener("click", () => {
     result.textContent = "";
+    hideStatus();
 
     if (!("geolocation" in navigator)) {
-      result.textContent = "このブラウザでは位置情報（Geolocation）が利用できません。";
+      showErrorStatus("このブラウザでは位置情報（Geolocation）が利用できません。");
       return;
     }
 
-    result.textContent = "現在地を取得しています...";
+    showLoadingStatus("現在地を取得しています...");
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -91,11 +101,16 @@ function setupGeolocationButton() {
         result.textContent =
           `取得できました。緯度: ${lat.toFixed(6)}, 経度: ${lng.toFixed(6)}（精度: 約${Math.round(accuracy)}m）`;
 
+        showLoadingStatus("地図を準備しています...");
+
         loadGoogleMap(apiKey, lat, lng, toilets);
       },
       (error) => {
-        result.textContent = errorMessageFromGeolocationError(error);
+        hideStatus();
+        clearToiletList();
+        showErrorStatus(errorMessageFromGeolocationError(error));
       },
+
       {
         enableHighAccuracy: true,
         timeout: 8000,
@@ -152,6 +167,13 @@ function initMap(lat, lng, toilets) {
 
   renderToiletMarkers(toilets);
   renderToiletList(toilets);
+
+  // ✅ 0件表示
+  if (!Array.isArray(toilets) || toilets.length === 0) {
+    showEmptyStatus("現在地周辺に登録されているトイレが見つかりませんでした。");
+  } else {
+    hideStatus();
+  }
 }
 
 /* --------------------
@@ -281,6 +303,51 @@ function markOrUnknown(value) {
   return "—"; // 未登録(null/undefined)用
 }
 
+function getSearchStatusEl() {
+  return document.getElementById("search-status");
+}
+
+function showLoadingStatus(message = "検索中...") {
+  const el = getSearchStatusEl();
+  if (!el) return;
+
+  el.className = "search-status is-show is-loading";
+  el.innerHTML = `
+    <span class="search-status__spinner" aria-hidden="true"></span>
+    <span>${escapeHtml(message)}</span>
+  `;
+}
+
+function showEmptyStatus(message = "近くにトイレが見つかりませんでした。") {
+  const el = getSearchStatusEl();
+  if (!el) return;
+
+  el.className = "search-status is-show is-empty";
+  el.textContent = message;
+}
+
+function showErrorStatus(message = "エラーが発生しました。もう一度お試しください。") {
+  const el = getSearchStatusEl();
+  if (!el) return;
+
+  el.className = "search-status is-show is-error";
+  el.textContent = message;
+}
+
+function hideStatus() {
+  const el = getSearchStatusEl();
+  if (!el) return;
+
+  el.className = "search-status";
+  el.textContent = "";
+}
+
+function clearToiletList() {
+  const list = document.getElementById("toilet-list");
+  if (!list) return;
+  list.innerHTML = "";
+}
+
 function handleToiletSelect(toilet, panTargetLatLng) {
   // 選択状態を更新
   selectToilet(toilet);
@@ -343,9 +410,6 @@ function openToiletModal(toilet) {
   const ostomate   = toilet.is_ostomate_accessible ? "〇" : "×";
   const baby       = toilet.is_baby_friendly ? "〇" : "×";
 
-  // 男女別 / 共用 は文字（issueの文言どおり）
-  const genderText = toilet.is_gender_separated ? "男女別" : "共用";
-
   // ✅ issue仕様：Google Map ナビ用URL（緯度経度）
   const lat = Number(toilet.latitude);
   const lng = Number(toilet.longitude);
@@ -354,6 +418,7 @@ function openToiletModal(toilet) {
     ? `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=walking`
     : "";
 
+  // toilet.has_washlet は本リリースでDB追加予定（現状は undefined → "—" 表示）
   modalBody.innerHTML = `
     <div class="toilet-modal__header">
       <div>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -23,6 +23,8 @@
   ).to_json %>"
 ></div>
 
+<div id="search-status" class="search-status" aria-live="polite"></div>
+
 <div id="toilet-list" style="margin-top: 12px;"></div>
 
 <!-- ▼ トイレ詳細モーダル（JSで中身を差し替える） -->


### PR DESCRIPTION
## 概要
トイレ検索時のローディング表示、エラー表示、検索結果0件時の表示を追加しました。

## 変更内容
- 検索開始時にローディング表示を追加
- 位置情報取得後〜トイレ一覧表示までローディングを継続表示
- トイレが0件の場合に案内メッセージを表示
- 位置情報取得失敗時のエラーメッセージを表示
- 想定外エラー時の汎用エラーメッセージを追加

## 目的
- 検索中・エラー時の状態をユーザーに分かりやすく伝えるため
- 不安や混乱を与えない UX を実現するため

## 動作確認
- 現在地取得中にローディングが表示されること
- 検索結果が0件の場合にメッセージが表示されること
- 位置情報取得エラー時にエラーメッセージが表示されること
- 正常時は地図・トイレ一覧表示後にローディングが非表示になること

## 関連Issue
Close #38 
