### PR TITLE
UIの調整

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,6 +9,34 @@
  * Consider organizing styles into separate files for maintainability.
  */
 /* layout */
+:root {
+  /* typography */
+  --fs-xxs: 11px;
+  --fs-xs: 12px;
+  --fs-sm: 13px;
+  --fs-md: 14px;
+  --fs-lg: 16px;
+
+  /* spacing */
+  --space-1: 6px;
+  --space-2: 8px;
+  --space-3: 10px;
+  --space-4: 12px;
+  --space-5: 16px;
+
+  /* fixed bars */
+  --header-pad-y: 10px;
+  --header-pad-x: 12px;
+
+  --footer-pad-y: 8px;
+  --footer-pad-x: 12px;
+
+  /* buttons */
+  --btn-pad-y: 12px;
+  --btn-pad-x: 14px;
+  --btn-radius: 12px;
+}
+
 #map {
   width: 100%;
   height: 320px; /* まずは固定でOK */
@@ -26,30 +54,29 @@
 .site-header__inner {
   max-width: 960px;
   margin: 0 auto;
-  padding: 12px 16px;
+  padding: var(--header-pad-y) var(--header-pad-x);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .site-logo {
   text-decoration: none;
   font-weight: 700;
   color: #111;
+  font-size: var(--fs-lg); /* 16px */
+  line-height: 1.2;
 }
 
 .site-main {
   max-width: 960px;
   margin: 0 auto;
   padding: 16px;
-  padding-bottom: 72px;
-}
 
-.site-footer__inner {
-  padding-bottom: calc(10px + env(safe-area-inset-bottom));
+  /* フッターが薄くなった分、余白も縮める */
+  padding-bottom: calc(44px + env(safe-area-inset-bottom));
 }
-
 
 /* nav */
 .site-nav__link {
@@ -80,11 +107,11 @@
 }
 
 .hamburger-btn {
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   display: grid;
   place-items: center;
-  border-radius: 12px;
+  border-radius: 10px;
   border: 1px solid #eee;
   background: #fff;
   cursor: pointer;
@@ -92,7 +119,7 @@
 }
 
 .hamburger-btn__icon {
-  font-size: 22px;
+  font-size: 20px;
   line-height: 1;
 }
 
@@ -100,13 +127,17 @@
   position: absolute;
   right: 0;
   top: calc(100% + 8px);
-  width: 200px;
+
+  width: 180px;
+  padding: 8px;
+
   border: 1px solid #eee;
   border-radius: 12px;
   background: #fff;
-  padding: 8px;
+
   display: grid;
   gap: 6px;
+
   z-index: 1001; /* headerより上 */
 }
 
@@ -167,26 +198,21 @@
 }
 
 .drawer__link {
-  text-decoration: none;
-  color: #111;
-  padding: 10px 10px;
+  padding: 8px 10px;
   border-radius: 10px;
+  font-size: var(--fs-md);
 }
 
 .drawer__link:hover {
   background: #f5f5f5;
 }
 
-/* pc breakpoint */
 @media (min-width: 768px) {
-  .site-nav--desktop {
-    display: flex;
-  }
-  .site-nav--mobile {
-    display: none;
-  }
-    .hero__actions {
-    grid-template-columns: 1fr;
+  .site-nav--desktop { display: flex; }
+  .site-nav--mobile  { display: none; }
+
+  .hero__actions {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -214,21 +240,23 @@
   gap: 10px;
 }
 
-.hero__actions .btn {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-}
-
 .btn {
   display: inline-block;
   text-align: center;
-  padding: 12px 14px;
-  border-radius: 12px;
+  padding: var(--btn-pad-y) var(--btn-pad-x);
+  border-radius: var(--btn-radius);
   text-decoration: none;
   border: 1px solid #ddd;
   color: #111;
   background: #fff;
+  font-size: var(--fs-lg);  /* 16px */
+  line-height: 1.1;
+}
+
+.btn--block {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .btn--primary {
@@ -239,6 +267,12 @@
 
 .btn--ghost:hover {
   background: #f5f5f5;
+}
+
+.search-retry {
+  padding: 8px 12px;         /* 全体(12px 14px)より小さく */
+  font-size: var(--fs-md);   /* 14px */
+  border-radius: 10px;
 }
 
 /* --- Toilet list (Search page) --- */
@@ -423,17 +457,11 @@ body.is-modal-open {
   color: #666;
 }
 
-/* 設備：PC 3列、スマホで 2列/1列へ */
+/* 設備：基本は3列（gapは6pxで統一） */
 .toilet-modal__grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-}
-
-.toilet-modal__grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 6px; /* 少し詰める */
+  gap: 6px;
 }
 
 .toilet-modal__cell {
@@ -549,52 +577,58 @@ body.is-modal-open {
   font-size: 13px;
 }
 
-/* --- Footer (overlay) --- */
 .site-footer {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
-
   border-top: 1px solid #eee;
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(6px);
-
   z-index: 20;
 }
 
 .site-footer__inner {
   max-width: 960px;
+  min-width: 0;
   margin: 0 auto;
-  padding: 10px 16px;
-  padding-bottom: calc(10px + env(safe-area-inset-bottom)); /* iPhone対策 */
-
+  padding: var(--footer-pad-y) var(--footer-pad-x);
+  padding-bottom: calc(var(--footer-pad-y) + env(safe-area-inset-bottom));
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .site-footer__logo {
   font-weight: 700;
   color: #111;
   text-decoration: none;
+  font-size: var(--fs-sm); /* 13px */
+  white-space: nowrap;
 }
 
+/* 1行維持＋溢れたら横スクロール */
 .site-footer__nav {
+  min-width: 0;
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 8px;
+  flex-wrap: nowrap;       /* ← ここが重要 */
+  overflow-x: auto;        /* ← ここが重要 */
+  -webkit-overflow-scrolling: touch;
   justify-content: flex-end;
 }
 
 .site-footer__link {
+  flex: 0 0 auto;
   text-decoration: none;
   color: #111;
-  padding: 6px 8px;
+  padding: 4px 6px;
   border-radius: 8px;
   opacity: 0.75;
+  font-size: var(--fs-sm); /* 13px */
+  white-space: nowrap;     /* ← 折り返さない */
 }
 
 .site-footer__link:hover {
@@ -645,4 +679,31 @@ body.is-modal-open {
   font-size: 13px;
   color: #444;
   line-height: 1.5;
+}
+
+/* ========== Mobile adjustments ========== */
+@media (max-width: 480px) {
+  /* フッターを1行で収めやすくする */
+  .site-footer__inner {
+    padding: 8px 12px;
+    gap: 10px;
+  }
+
+  .site-footer__logo {
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .site-footer__nav {
+    flex-wrap: nowrap;        /* 折り返しを止める（= 1行に寄せる） */
+    overflow-x: auto;         /* 入りきらない時は横スクロールで逃がす */
+    -webkit-overflow-scrolling: touch;
+    gap: 6px;
+  }
+
+  .site-footer__link {
+    padding: 3px 4px;
+    font-size: 11px;
+    white-space: nowrap;      /* “利用規約”などを途中で折らない */
+  }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -43,7 +43,13 @@
   max-width: 960px;
   margin: 0 auto;
   padding: 16px;
+  padding-bottom: 72px;
 }
+
+.site-footer__inner {
+  padding-bottom: calc(10px + env(safe-area-inset-bottom));
+}
+
 
 /* nav */
 .site-nav__link {
@@ -66,6 +72,66 @@
 /* mobile nav visible only on mobile */
 .site-nav--mobile {
   display: block;
+}
+
+/* --- Mobile menu (button + overlay) --- */
+.site-nav--mobile {
+  position: relative;
+}
+
+.hamburger-btn {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  border: 1px solid #eee;
+  background: #fff;
+  cursor: pointer;
+  padding: 0;
+}
+
+.hamburger-btn__icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.mobile-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: 200px;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  background: #fff;
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+  z-index: 1001; /* headerより上 */
+}
+
+.mobile-menu__link {
+  text-decoration: none;
+  color: #111;
+  padding: 10px 10px;
+  border-radius: 10px;
+}
+
+.mobile-menu__link:hover {
+  background: #f5f5f5;
+}
+
+/* backdrop */
+.mobile-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.08);
+  z-index: 1000;
+}
+
+.mobile-menu[hidden],
+.mobile-menu-backdrop[hidden] {
+  display: none !important;
 }
 
 /* hamburger */
@@ -119,6 +185,9 @@
   .site-nav--mobile {
     display: none;
   }
+    .hero__actions {
+    grid-template-columns: 1fr;
+  }
 }
 
 .hero {
@@ -145,6 +214,12 @@
   gap: 10px;
 }
 
+.hero__actions .btn {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .btn {
   display: inline-block;
   text-align: center;
@@ -166,17 +241,16 @@
   background: #f5f5f5;
 }
 
-@media (min-width: 768px) {
-  .hero__actions {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-}
-
 /* --- Toilet list (Search page) --- */
 #toilet-list {
   margin-top: 12px;
   display: grid;
   gap: 10px;
+
+  /* ▼ 追加：地図は固定で、一覧だけスクロールさせる */
+  max-height: 40vh;
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .toilet-card {
@@ -220,18 +294,19 @@
 }
 
 .toilet-card__detail {
-  border: 1px solid #e5e5e5;
-  background: #fff;
-  border-radius: 999px;
+  border: none;
+  background: transparent;
+  border-radius: 0;
   width: 32px;
   height: 32px;
   cursor: pointer;
-  line-height: 30px;
-  font-size: 18px;
+  line-height: 32px;
+  font-size: 22px;
+  opacity: 0.7;
 }
 
 .toilet-card__detail:hover {
-  background: #f5f5f5;
+  opacity: 1;
 }
 
 .toilet-card__detail:active {
@@ -241,6 +316,10 @@
 .facility-icon {
   font-size: 18px;
   line-height: 1;
+}
+
+body.is-modal-open {
+  overflow: hidden;
 }
 
 .toilet-modal {
@@ -264,23 +343,38 @@
 .toilet-modal__panel {
   position: absolute;
   left: 50%;
-  top: 10%;
-  transform: translateX(-50%);
+  top: 50%;
+  transform: translate(-50%, -50%);
+
   width: min(92vw, 520px);
+  max-height: calc(100vh - 24px);
+  overflow: auto;
+
   background: #fff;
   border-radius: 12px;
   padding: 16px;
   z-index: 1;
 }
 
+/* ×ボタン：右上、枠なし */
 .toilet-modal__close {
   position: absolute;
-  right: 12px;
   top: 12px;
+  right: 12px;
+
+  border: none;
+  background: transparent;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
   z-index: 2;
 }
 
-/* modal body (optional) */
+.toilet-modal__close:hover {
+  opacity: 0.6;
+}
+
+/* modal body */
 .toilet-modal__body {
   display: grid;
   gap: 10px;
@@ -296,27 +390,28 @@
   font-weight: 700;
 }
 
-.toilet-modal__icons {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
+/* タイトル + ☆ を同じ行で並べる */
 .toilet-modal__titleRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
+  padding-right: 40px; /* ×ボタン分の余白 */
 }
 
-.toilet-modal__fav {
-  border: 1px solid #e5e5e5;
-  background: #fff;
-  border-radius: 999px;
-  width: 36px;
-  height: 36px;
+/* ☆ボタン：枠なし・右横に自然に */
+.toilet-modal__fav,
+.toilet-modal__favHint {
+  border: none;
+  background: transparent;
+  padding: 4px;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.toilet-modal__fav:hover,
+.toilet-modal__favHint:hover {
+  opacity: 0.7;
 }
 
 .toilet-modal__photoPlaceholder {
@@ -328,19 +423,58 @@
   color: #666;
 }
 
+/* 設備：PC 3列、スマホで 2列/1列へ */
 .toilet-modal__grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 8px;
 }
 
+.toilet-modal__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px; /* 少し詰める */
+}
+
 .toilet-modal__cell {
   border: 1px solid #e5e5e5;
   border-radius: 10px;
-  padding: 10px 8px;
-  text-align: center;
+  padding: 8px 6px;
   background: #fff;
-  font-size: 13px;
+
+  display: grid;
+  gap: 6px;
+  align-content: start;
+}
+
+.toilet-modal__cellLabel {
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.2;
+
+  /* はみ出し対策 */
+  word-break: keep-all;
+}
+
+/* 区切り線：カード枠と同系色 */
+.toilet-modal__cellDivider {
+  height: 1px;
+  background: #e5e5e5;
+}
+
+/* 〇/×：中央、太さは残しつつ“強すぎ”を抑える */
+.toilet-modal__cellValue {
+  text-align: center;
+  font-size: 16px; /* 18 → 16 */
+  font-weight: 700;
+  line-height: 1;
+  min-height: 16px;
+}
+
+.toilet-modal__cellValue--text {
+  font-size: 16px;
+  font-weight: 700;
 }
 
 .toilet-modal__sectionTitle {
@@ -359,6 +493,7 @@
   width: 100%;
   margin-top: 6px;
 }
+
 .search-status {
   margin-top: 12px;
   padding: 12px;
@@ -399,4 +534,115 @@
 .search-status.is-empty {
   border-color: #eee;
   background: #fafafa;
+}
+
+.search-toolbar {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+/* 生ログ（緯度経度など）を出すならここで整える */
+.search-debug {
+  margin: 0;
+  color: #444;
+  font-size: 13px;
+}
+
+/* --- Footer (overlay) --- */
+.site-footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  border-top: 1px solid #eee;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(6px);
+
+  z-index: 20;
+}
+
+.site-footer__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 10px 16px;
+  padding-bottom: calc(10px + env(safe-area-inset-bottom)); /* iPhone対策 */
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.site-footer__logo {
+  font-weight: 700;
+  color: #111;
+  text-decoration: none;
+}
+
+.site-footer__nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.site-footer__link {
+  text-decoration: none;
+  color: #111;
+  padding: 6px 8px;
+  border-radius: 8px;
+  opacity: 0.75;
+}
+
+.site-footer__link:hover {
+  opacity: 1;
+  background: #f5f5f5;
+}
+
+.feature {
+  margin-top: 24px;
+}
+
+.feature__placeholder {
+  height: 180px;
+  border-radius: 12px;
+  background: #e5e5e5;
+  display: grid;
+  place-items: center;
+  color: #666;
+}
+
+.cta {
+  margin-top: 24px;
+  display: grid;
+  gap: 10px;
+}
+
+/* top page: feature/cta inside hero */
+.feature--in-hero {
+  margin-top: 14px;
+}
+
+.cta--in-hero {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.feature__img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 12px;
+  border: 1px solid #eee;
+}
+
+.feature__caption {
+  margin: 10px 0 0;
+  font-size: 13px;
+  color: #444;
+  line-height: 1.5;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,14 +1,3 @@
-/*
- * This is a manifest file that'll be compiled into application.css.
- *
- * With Propshaft, assets are served efficiently without preprocessing steps. You can still include
- * application-wide styles in this file, but keep in mind that CSS precedence will follow the standard
- * cascading order, meaning styles declared later in the document or manifest will override earlier ones,
- * depending on specificity.
- *
- * Consider organizing styles into separate files for maintainability.
- */
-/* layout */
 :root {
   /* typography */
   --fs-xxs: 11px;
@@ -39,7 +28,7 @@
 
 #map {
   width: 100%;
-  height: 320px; /* まずは固定でOK */
+  height: 320px;
   border-radius: 12px;
 }
 
@@ -65,7 +54,7 @@
   text-decoration: none;
   font-weight: 700;
   color: #111;
-  font-size: var(--fs-lg); /* 16px */
+  font-size: var(--fs-lg);
   line-height: 1.2;
 }
 
@@ -74,11 +63,9 @@
   margin: 0 auto;
   padding: 16px;
 
-  /* フッターが薄くなった分、余白も縮める */
   padding-bottom: calc(44px + env(safe-area-inset-bottom));
 }
 
-/* nav */
 .site-nav__link {
   text-decoration: none;
   color: #111;
@@ -90,18 +77,15 @@
   background: #f5f5f5;
 }
 
-/* desktop nav visible only on pc */
 .site-nav--desktop {
   display: none;
   gap: 8px;
 }
 
-/* mobile nav visible only on mobile */
 .site-nav--mobile {
   display: block;
 }
 
-/* --- Mobile menu (button + overlay) --- */
 .site-nav--mobile {
   position: relative;
 }
@@ -138,7 +122,7 @@
   display: grid;
   gap: 6px;
 
-  z-index: 1001; /* headerより上 */
+  z-index: 1001;
 }
 
 .mobile-menu__link {
@@ -152,7 +136,6 @@
   background: #f5f5f5;
 }
 
-/* backdrop */
 .mobile-menu-backdrop {
   position: fixed;
   inset: 0;
@@ -249,7 +232,7 @@
   border: 1px solid #ddd;
   color: #111;
   background: #fff;
-  font-size: var(--fs-lg);  /* 16px */
+  font-size: var(--fs-lg);
   line-height: 1.1;
 }
 
@@ -270,18 +253,17 @@
 }
 
 .search-retry {
-  padding: 8px 12px;         /* 全体(12px 14px)より小さく */
-  font-size: var(--fs-md);   /* 14px */
+  padding: 8px 12px;
+  font-size: var(--fs-md);
   border-radius: 10px;
 }
 
-/* --- Toilet list (Search page) --- */
+/* --- トイレ一覧 --- */
 #toilet-list {
   margin-top: 12px;
   display: grid;
   gap: 10px;
 
-  /* ▼ 追加：地図は固定で、一覧だけスクロールさせる */
   max-height: 40vh;
   overflow: auto;
   padding-right: 2px;
@@ -390,7 +372,6 @@ body.is-modal-open {
   z-index: 1;
 }
 
-/* ×ボタン：右上、枠なし */
 .toilet-modal__close {
   position: absolute;
   top: 12px;
@@ -408,7 +389,6 @@ body.is-modal-open {
   opacity: 0.6;
 }
 
-/* modal body */
 .toilet-modal__body {
   display: grid;
   gap: 10px;
@@ -424,15 +404,14 @@ body.is-modal-open {
   font-weight: 700;
 }
 
-/* タイトル + ☆ を同じ行で並べる */
 .toilet-modal__titleRow {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding-right: 40px; /* ×ボタン分の余白 */
+  padding-right: 40px;
 }
 
-/* ☆ボタン：枠なし・右横に自然に */
+
 .toilet-modal__fav,
 .toilet-modal__favHint {
   border: none;
@@ -457,7 +436,6 @@ body.is-modal-open {
   color: #666;
 }
 
-/* 設備：基本は3列（gapは6pxで統一） */
 .toilet-modal__grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -481,17 +459,14 @@ body.is-modal-open {
   text-align: center;
   line-height: 1.2;
 
-  /* はみ出し対策 */
   word-break: keep-all;
 }
 
-/* 区切り線：カード枠と同系色 */
 .toilet-modal__cellDivider {
   height: 1px;
   background: #e5e5e5;
 }
 
-/* 〇/×：中央、太さは残しつつ“強すぎ”を抑える */
 .toilet-modal__cellValue {
   text-align: center;
   font-size: 16px; /* 18 → 16 */
@@ -528,7 +503,7 @@ body.is-modal-open {
   border: 1px solid #eee;
   border-radius: 12px;
   background: #fff;
-  display: none; /* 使う時だけ表示 */
+  display: none;
 }
 
 .search-status.is-show {
@@ -570,7 +545,6 @@ body.is-modal-open {
   margin-bottom: 12px;
 }
 
-/* 生ログ（緯度経度など）を出すならここで整える */
 .search-debug {
   margin: 0;
   color: #444;
@@ -604,18 +578,17 @@ body.is-modal-open {
   font-weight: 700;
   color: #111;
   text-decoration: none;
-  font-size: var(--fs-sm); /* 13px */
+  font-size: var(--fs-sm);
   white-space: nowrap;
 }
 
-/* 1行維持＋溢れたら横スクロール */
 .site-footer__nav {
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: nowrap;       /* ← ここが重要 */
-  overflow-x: auto;        /* ← ここが重要 */
+  flex-wrap: nowrap;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   justify-content: flex-end;
 }
@@ -627,8 +600,8 @@ body.is-modal-open {
   padding: 4px 6px;
   border-radius: 8px;
   opacity: 0.75;
-  font-size: var(--fs-sm); /* 13px */
-  white-space: nowrap;     /* ← 折り返さない */
+  font-size: var(--fs-sm);
+  white-space: nowrap;
 }
 
 .site-footer__link:hover {
@@ -655,7 +628,6 @@ body.is-modal-open {
   gap: 10px;
 }
 
-/* top page: feature/cta inside hero */
 .feature--in-hero {
   margin-top: 14px;
 }
@@ -681,9 +653,8 @@ body.is-modal-open {
   line-height: 1.5;
 }
 
-/* ========== Mobile adjustments ========== */
+/*モバイル*/
 @media (max-width: 480px) {
-  /* フッターを1行で収めやすくする */
   .site-footer__inner {
     padding: 8px 12px;
     gap: 10px;
@@ -695,8 +666,8 @@ body.is-modal-open {
   }
 
   .site-footer__nav {
-    flex-wrap: nowrap;        /* 折り返しを止める（= 1行に寄せる） */
-    overflow-x: auto;         /* 入りきらない時は横スクロールで逃がす */
+    flex-wrap: nowrap;       
+    overflow-x: auto;        
     -webkit-overflow-scrolling: touch;
     gap: 6px;
   }
@@ -704,6 +675,6 @@ body.is-modal-open {
   .site-footer__link {
     padding: 3px 4px;
     font-size: 11px;
-    white-space: nowrap;      /* “利用規約”などを途中で折らない */
+    white-space: nowrap;     
   }
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,5 @@
 import "@hotwired/turbo-rails"
 import "geolocation"
 import "controllers"
+import "auth_placeholder"
+import "mobile_menu"

--- a/app/javascript/auth_placeholder.js
+++ b/app/javascript/auth_placeholder.js
@@ -1,0 +1,8 @@
+document.addEventListener("turbo:load", () => {
+  document.querySelectorAll(".js-auth-coming-soon").forEach((el) => {
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      alert("ログイン/新規登録は本リリースで対応予定です");
+    });
+  });
+});

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -80,7 +80,6 @@ function setupGeolocationButton() {
     });
   }
 
-  // ✅ 追加：位置情報取得を関数化（ここが本体）
   function startGeolocation() {
     result.textContent = "";
     hideStatus();
@@ -117,12 +116,10 @@ function setupGeolocationButton() {
     );
   }
 
-  // ✅ ボタンは再試行
   button.addEventListener("click", () => {
     startGeolocation();
   });
 
-  // ✅ /search 表示時に自動開始
   startGeolocation();
 }
 
@@ -144,7 +141,6 @@ function loadGoogleMap(apiKey, lat, lng, toilets) {
   const script = document.createElement("script");
   script.id = "google-maps-script";
 
-  // 警告を減らす：loading=async を付与（callbackは維持）
   script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&callback=__initGoogleMap&loading=async`;
 
   script.async = true;
@@ -154,10 +150,9 @@ function loadGoogleMap(apiKey, lat, lng, toilets) {
 function initMap(lat, lng, toilets) {
   map = new google.maps.Map(document.getElementById("map"), {
     center: { lat, lng },
-    zoom: 12, // トイレが散らばっているので少し広めに（必要なら16に戻してOK）
+    zoom: 12,
   });
 
-  // 現在地ピン（見分けやすく青）
   const currentMarker = new google.maps.Marker({
     position: { lat, lng },
     map: map,
@@ -165,17 +160,13 @@ function initMap(lat, lng, toilets) {
     icon: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png",
   });
 
-  // ✅ 現在地ピンもクリックで中心移動（あなたの意図どおり）
   currentMarker.addListener("click", () => {
     map.panTo(currentMarker.getPosition());
-    // ついでにズームも寄せたいなら↓（MVPなら好み）
-    // map.setZoom(16);
   });
 
   renderToiletMarkers(toilets);
   renderToiletList(toilets);
 
-  // ✅ 0件表示
   if (!Array.isArray(toilets) || toilets.length === 0) {
     showEmptyStatus("現在地周辺に登録されているトイレが見つかりませんでした。");
   } else {
@@ -183,9 +174,6 @@ function initMap(lat, lng, toilets) {
   }
 }
 
-/* --------------------
-   トイレのピン描画
--------------------- */
 function renderToiletMarkers(toilets) {
   toiletMarkersById = {};
 
@@ -206,17 +194,10 @@ function renderToiletMarkers(toilets) {
         lat: Number(toilet.latitude),
         lng: Number(toilet.longitude),
       });
-      // map.setZoom(16); // 寄せたいなら
     });
   });
 }
 
-/* --------------------
-   トイレ一覧描画（簡易）
-   - 運営会社名 + 駅名
-   - booleanはアイコン
-   - 選択状態ハイライト
--------------------- */
 function renderToiletList(toilets) {
   const list = document.getElementById("toilet-list");
   if (!list) return;
@@ -296,7 +277,6 @@ function highlightSelectedMarker(toiletId) {
   });
 }
 
-// XSS対策（最低限）
 function escapeHtml(str) {
   return String(str).replace(/[&<>"']/g, (s) => {
     const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
@@ -307,7 +287,7 @@ function escapeHtml(str) {
 function markOrUnknown(value) {
   if (value === true) return "〇";
   if (value === false) return "×";
-  return "—"; // 未登録(null/undefined)用
+  return "—";
 }
 
 function getSearchStatusEl() {
@@ -356,10 +336,8 @@ function clearToiletList() {
 }
 
 function handleToiletSelect(toilet, panTargetLatLng) {
-  // 選択状態を更新
   selectToilet(toilet);
 
-  // 地図を中心へ
   if (panTargetLatLng) {
     map.panTo(panTargetLatLng);
   }
@@ -414,12 +392,10 @@ function openToiletModal(toilet) {
 
   const loggedIn = isLoggedIn();
 
-  // ✅ issue仕様：設備は「〇/×」で表示（男女別/共用、和式/洋式は文字）
   const wheelchair = toilet.is_wheelchair_accessible ? "〇" : "×";
   const ostomate   = toilet.is_ostomate_accessible ? "〇" : "×";
   const baby       = toilet.is_baby_friendly ? "〇" : "×";
 
-  // ✅ issue仕様：Google Map ナビ用URL（緯度経度）
   const lat = Number(toilet.latitude);
   const lng = Number(toilet.longitude);
   const canNavigate = Number.isFinite(lat) && Number.isFinite(lng);
@@ -427,7 +403,6 @@ function openToiletModal(toilet) {
     ? `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=walking`
     : "";
 
-  // toilet.has_washlet は本リリースでDB追加予定（現状は undefined → "—" 表示）
   modalBody.innerHTML = `
     <div class="toilet-modal__header">
       <div>
@@ -448,7 +423,7 @@ function openToiletModal(toilet) {
       <div class="toilet-modal__photoPlaceholder">写真表示エリア（MVPは後でOK）</div>
     </div>
 
-    <!-- ✅ issue仕様：設備情報 -->
+    <!--  issue仕様：設備情報 -->
     <div class="toilet-modal__section">
       <div class="toilet-modal__sectionTitle">設備情報</div>
 
@@ -536,7 +511,6 @@ function bindToiletModalEvents(toilet) {
   const modalBody = document.getElementById("toilet-modal-body");
   if (!modalBody) return;
 
-  // ☆（ログイン中）
   const favBtn = modalBody.querySelector(".toilet-modal__fav");
   if (favBtn) {
     favBtn.onclick = () => {
@@ -544,17 +518,14 @@ function bindToiletModalEvents(toilet) {
     };
   }
 
-  // ☆（未ログイン：ログイン誘導）
   const favHintBtn = modalBody.querySelector(".toilet-modal__favHint");
   if (favHintBtn) {
     favHintBtn.onclick = () => {
       alert("お気に入り機能を使うにはログインが必要です");
-      // 将来：ログイン画面へ誘導するなら
-      // window.location.href = "/login";
+
     };
   }
 
-  // ルート案内（data-nav-url を優先）
   const routeBtn = modalBody.querySelector(".toilet-modal__route");
   if (routeBtn) {
     routeBtn.onclick = () => {
@@ -570,7 +541,6 @@ function openRouteInGoogleMaps(toilet) {
   const lng = Number(toilet.longitude);
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
 
-  // 現在地→目的地 のルート（Google Maps）
   const url = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=walking`;
   window.open(url, "_blank", "noopener,noreferrer");
 }

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -50,6 +50,7 @@ function setupGeolocationButton() {
   button.dataset.geolocationBound = "true";
 
   const apiKey = mapElement.dataset.mapApiKeyValue;
+
   let toilets = [];
   try {
     const toiletsJson = mapElement.dataset.mapToiletsValue || "[]";
@@ -59,8 +60,6 @@ function setupGeolocationButton() {
     clearToiletList();
     showErrorStatus("データの読み込みに失敗しました。ページを再読み込みしてください。");
   }
-
-
 
   const modalClose = document.getElementById("toilet-modal-close");
   const modalBackdrop = document.getElementById("toilet-modal-backdrop");
@@ -81,7 +80,8 @@ function setupGeolocationButton() {
     });
   }
 
-  button.addEventListener("click", () => {
+  // ✅ 追加：位置情報取得を関数化（ここが本体）
+  function startGeolocation() {
     result.textContent = "";
     hideStatus();
 
@@ -98,11 +98,10 @@ function setupGeolocationButton() {
         const lng = position.coords.longitude;
         const accuracy = position.coords.accuracy;
 
-        result.textContent =
-          `取得できました。緯度: ${lat.toFixed(6)}, 経度: ${lng.toFixed(6)}（精度: 約${Math.round(accuracy)}m）`;
-
+        result.textContent = "";
+          `lat=${lat.toFixed(6)}, lng=${lng.toFixed(6)}（精度: 約${Math.round(accuracy)}m）`;
         showLoadingStatus("地図を準備しています...");
-
+        
         loadGoogleMap(apiKey, lat, lng, toilets);
       },
       (error) => {
@@ -110,15 +109,23 @@ function setupGeolocationButton() {
         clearToiletList();
         showErrorStatus(errorMessageFromGeolocationError(error));
       },
-
       {
         enableHighAccuracy: true,
         timeout: 8000,
         maximumAge: 0,
       }
     );
+  }
+
+  // ✅ ボタンは再試行
+  button.addEventListener("click", () => {
+    startGeolocation();
   });
+
+  // ✅ /search 表示時に自動開始
+  startGeolocation();
 }
+
 
 function loadGoogleMap(apiKey, lat, lng, toilets) {
   if (window.google && window.google.maps && typeof window.google.maps.Map === "function") {
@@ -364,6 +371,8 @@ function closeToiletModal() {
 
   modal.classList.remove("is-open");
   modal.setAttribute("aria-hidden", "true");
+
+  document.body.classList.remove("is-modal-open");
 }
 
 function setupToiletModalCloseEvents() {
@@ -445,22 +454,46 @@ function openToiletModal(toilet) {
 
       <div class="toilet-modal__grid">
         <div class="toilet-modal__cell">
-          ウォシュレット：${markOrUnknown(toilet.has_washlet)}
+          <div class="toilet-modal__cellLabel">便器タイプ</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue toilet-modal__cellValue--text">
+            ${escapeHtml(styleText)}
+          </div>
+        </div>
+
+        <div class="toilet-modal__cell">
+          <div class="toilet-modal__cellLabel">ウォシュレット</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.has_washlet)}</div>
+        </div>
+
+        <div class="toilet-modal__cell">
+          <div class="toilet-modal__cellLabel">おむつ交換設備</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.is_baby_friendly)}</div>
+        </div>
+
+        <div class="toilet-modal__cell">
+          <div class="toilet-modal__cellLabel">多目的トイレ</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.is_multipurpose)}</div>
+        </div>
+
+        <div class="toilet-modal__cell">
+          <div class="toilet-modal__cellLabel">車いす対応</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.is_wheelchair_accessible)}</div>
+        </div>
+
+        <div class="toilet-modal__cell">
+          <div class="toilet-modal__cellLabel">オストメイト対応</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.is_ostomate_accessible)}</div>
         </div>
         <div class="toilet-modal__cell">
-          おむつ交換設備：${markOrUnknown(toilet.is_baby_friendly)}
-        </div>
-        <div class="toilet-modal__cell">
-          多目的トイレ：${markOrUnknown(toilet.is_multipurpose)}
-        </div>
-        <div class="toilet-modal__cell">
-          車いす対応：${markOrUnknown(toilet.is_wheelchair_accessible)}
-        </div>
-        <div class="toilet-modal__cell">
-          オストメイト対応：${markOrUnknown(toilet.is_ostomate_accessible)}
-        </div>
-        <div class="toilet-modal__cell">
-          男女別：${markOrUnknown(toilet.is_gender_separated)}
+          <div class="toilet-modal__cellLabel">男女別</div>
+          <div class="toilet-modal__cellDivider"></div>
+          <div class="toilet-modal__cellValue">${markOrUnknown(toilet.is_gender_separated)}</div>
         </div>
       </div>
     </div>
@@ -494,6 +527,8 @@ function openToiletModal(toilet) {
 
   modal.classList.add("is-open");
   modal.setAttribute("aria-hidden", "false");
+
+  document.body.classList.add("is-modal-open");
 }
 
 

--- a/app/javascript/mobile_menu.js
+++ b/app/javascript/mobile_menu.js
@@ -1,0 +1,50 @@
+function setupMobileMenu() {
+  const btn = document.querySelector("[data-mobile-menu-button]");
+  const menu = document.querySelector("[data-mobile-menu]");
+  const icon = document.querySelector("[data-mobile-menu-icon]");
+  const backdrop = document.querySelector("[data-mobile-menu-backdrop]");
+
+  if (!btn || !menu || !icon || !backdrop) return;
+
+  // Turbo再訪で多重登録防止
+  if (btn.dataset.bound === "true") return;
+  btn.dataset.bound = "true";
+
+  function openMenu() {
+    menu.hidden = false;
+    backdrop.hidden = false;
+    btn.setAttribute("aria-expanded", "true");
+    icon.textContent = "×";
+  }
+
+  function closeMenu() {
+    menu.hidden = true;
+    backdrop.hidden = true;
+    btn.setAttribute("aria-expanded", "false");
+    icon.textContent = "☰";
+  }
+
+  function toggleMenu() {
+    const isOpen = btn.getAttribute("aria-expanded") === "true";
+    if (isOpen) closeMenu();
+    else openMenu();
+  }
+
+  btn.addEventListener("click", toggleMenu);
+
+  // 外側タップで閉じる
+  backdrop.addEventListener("click", closeMenu);
+
+  // ESCで閉じる
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeMenu();
+  });
+
+  // メニュークリックで閉じたい場合（任意）
+  menu.addEventListener("click", (e) => {
+    const target = e.target;
+    if (target && target.tagName === "A") closeMenu();
+  });
+}
+
+document.addEventListener("turbo:load", setupMobileMenu);

--- a/app/javascript/mobile_menu.js
+++ b/app/javascript/mobile_menu.js
@@ -32,15 +32,12 @@ function setupMobileMenu() {
 
   btn.addEventListener("click", toggleMenu);
 
-  // 外側タップで閉じる
   backdrop.addEventListener("click", closeMenu);
 
-  // ESCで閉じる
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") closeMenu();
   });
 
-  // メニュークリックで閉じたい場合（任意）
   menu.addEventListener("click", (e) => {
     const target = e.target;
     if (target && target.tagName === "A") closeMenu();

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,11 @@
+<footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__logo">トイレナビ</div>
+
+    <nav class="site-footer__nav" aria-label="フッターメニュー">
+      <%= link_to "お問い合わせ", "#", class: "site-footer__link" %>
+      <%= link_to "利用規約", "#", class: "site-footer__link" %>
+      <%= link_to "プライバシーポリシー", "#", class: "site-footer__link" %>
+    </nav>
+  </div>
+</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,9 +58,9 @@
             data-mobile-menu
             hidden
           >
-            <%= link_to "トイレを探す", search_path, class: "drawer__link" %>
-            <%= link_to "新規登録", "#", class: "drawer__link js-auth-coming-soon" %>
-            <%= link_to "ログイン", "#", class: "drawer__link js-auth-coming-soon" %>
+            <%= link_to "トイレを探す", search_path, class: "mobile-menu__link" %>
+            <%= link_to "新規登録", "#", class: "mobile-menu__link js-auth-coming-soon" %>
+            <%= link_to "ログイン", "#", class: "mobile-menu__link js-auth-coming-soon" %>
           </nav>
           <div class="mobile-menu-backdrop" data-mobile-menu-backdrop hidden></div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,30 +30,57 @@
         </div>
 
         <!-- PC向けナビ（横並び） -->
-        <nav class="site-nav site-nav--desktop" aria-label="メインメニュー">
-          <%= link_to "お問い合わせ", contact_path, class: "site-nav__link" %>
-          <%= link_to "利用規約", terms_path, class: "site-nav__link" %>
-          <%= link_to "プライバシー", privacy_path, class: "site-nav__link" %>
+        <nav class="site-nav site-nav--desktop">
+          <%= link_to "トイレを探す", search_path, class: "site-nav__link" %>
+          <%= link_to "新規登録", "#", class: "site-nav__link js-auth-coming-soon" %>
+          <%= link_to "ログイン", "#", class: "site-nav__link js-auth-coming-soon" %>
+
         </nav>
 
-        <!-- スマホ向け：ハンバーガー（detailsでJS不要） -->
-        <details class="site-nav site-nav--mobile">
-          <summary class="hamburger" aria-label="メニューを開く">
-            <span class="hamburger__bar"></span>
-            <span class="hamburger__bar"></span>
-            <span class="hamburger__bar"></span>
-          </summary>
 
-          <nav class="drawer" aria-label="メインメニュー（モバイル）">
-            <%= link_to "お問い合わせ", contact_path, class: "drawer__link" %>
-            <%= link_to "利用規約", terms_path, class: "drawer__link" %>
-            <%= link_to "プライバシー", privacy_path, class: "drawer__link" %>
+        <!-- スマホ向け：ハンバーガー -->
+        <div class="site-nav site-nav--mobile">
+          <button
+            type="button"
+            class="hamburger-btn"
+            aria-label="メニューを開く"
+            aria-expanded="false"
+            aria-controls="mobile-menu"
+            data-mobile-menu-button
+          >
+            <span class="hamburger-btn__icon" data-mobile-menu-icon>☰</span>
+          </button>
+
+          <nav
+            id="mobile-menu"
+            class="mobile-menu"
+            aria-label="メインメニュー（モバイル）"
+            data-mobile-menu
+            hidden
+          >
+            <%= link_to "トイレを探す", search_path, class: "drawer__link" %>
+            <%= link_to "新規登録", "#", class: "drawer__link js-auth-coming-soon" %>
+            <%= link_to "ログイン", "#", class: "drawer__link js-auth-coming-soon" %>
           </nav>
-        </details>
+          <div class="mobile-menu-backdrop" data-mobile-menu-backdrop hidden></div>
+        </div>
       </div>
     </header>   
     <main class="site-main">
       <%= yield %>
     </main>
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__left">
+          <%= link_to "トイレナビ", root_path, class: "site-footer__logo" %>
+        </div>
+
+        <nav class="site-footer__nav" aria-label="フッターナビゲーション">
+          <%= link_to "お問い合わせ", contact_path, class: "site-footer__link" %>
+          <%= link_to "利用規約", terms_path, class: "site-footer__link" %>
+          <%= link_to "プライバシーポリシー", privacy_path, class: "site-footer__link" %>
+        </nav>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,14 +1,31 @@
 <section class="hero">
   <h1 class="hero__title">トイレナビ</h1>
   <p class="hero__lead">
-    近くのトイレをすばやく探せるサービスです。
+    今いる場所から、条件に合ったトイレをすぐに見つけられます
   </p>
 
   <div class="hero__actions">
     <%= link_to "探す", search_path, class: "btn btn--primary" %>
+  </div>
 
-    <%# ログイン/新規登録は本リリース以降で実装予定 %>
-    <%#= link_to "ログイン", "#", class: "btn btn--ghost" %>
-    <%#= link_to "新規登録", "#", class: "btn btn--ghost" %>
+  <section class="feature feature--in-hero">
+    <div class="feature__image">
+      <%= image_tag "home_guide_01.png",
+        class: "feature__img",
+        alt: "トイレナビの使い方イメージ" rescue nil %>
+
+      <noscript>
+        <div class="feature__placeholder">アプリの使い方イメージ</div>
+      </noscript>
+    </div>
+
+    <p class="feature__caption">
+      現在地から近いトイレを地図で確認し、詳細からGoogleマップで案内を開始できます。
+    </p>
+  </section>
+
+  <div class="hero__actions">
+    <%= link_to "新規登録する", "#", class: "btn btn--primary js-auth-coming-soon" %>
+    <%= link_to "ログイン", "#", class: "btn js-auth-coming-soon" %>
   </div>
 </section>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,11 +1,10 @@
 <section class="hero">
-  <h1 class="hero__title">トイレナビ</h1>
   <p class="hero__lead">
     今いる場所から、条件に合ったトイレをすぐに見つけられます
   </p>
 
   <div class="hero__actions">
-    <%= link_to "探す", search_path, class: "btn btn--primary" %>
+    <%= link_to "探す", search_path, class: "btn btn--primary btn--block" %>
   </div>
 
   <section class="feature feature--in-hero">
@@ -25,7 +24,7 @@
   </section>
 
   <div class="hero__actions">
-    <%= link_to "新規登録する", "#", class: "btn btn--primary js-auth-coming-soon" %>
-    <%= link_to "ログイン", "#", class: "btn js-auth-coming-soon" %>
+    <%= link_to "新規登録する", "#", class: "btn btn--primary btn--block js-auth-coming-soon" %>
+    <%= link_to "ログイン", "#", class: "btn btn--block js-auth-coming-soon" %>
   </div>
 </section>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,6 +1,6 @@
 <div class="search-toolbar">
   <p id="location-result" hidden></p>
-
+</div>
 <div
   id="map"
   data-is-logged-in-value="false"

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,12 +1,5 @@
-<h1>トイレを探す</h1>
-
-<p>現在地から近いトイレを探します。</p>
-
-<button type="button" id="get-location" class="btn btn--primary">
-  現在地を取得する
-</button>
-
-<p id="location-result" style="margin-top: 12px;"></p>
+<div class="search-toolbar">
+  <p id="location-result" hidden></p>
 
 <div
   id="map"
@@ -25,9 +18,12 @@
 
 <div id="search-status" class="search-status" aria-live="polite"></div>
 
-<div id="toilet-list" style="margin-top: 12px;"></div>
+<button type="button" id="get-location" class="btn btn--primary search-retry">
+  位置情報を再取得する
+</button>
 
-<!-- ▼ トイレ詳細モーダル（JSで中身を差し替える） -->
+<div id="toilet-list"></div>
+
 <div id="toilet-modal" class="toilet-modal" aria-hidden="true">
   <div id="toilet-modal-backdrop" class="toilet-modal__backdrop"></div>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,5 +4,7 @@ pin "application"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin "mobile_menu", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "geolocation"
+pin "auth_placeholder"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,23 +1,104 @@
-Station.where(operator_name: "JR東日本", name: "大宮駅").destroy_all
+# db/seeds.rb
+Rails.application.eager_load!
 
-station = Station.create!(
-  name: "大宮駅",
-  operator_name: "JR東日本",
-  latitude: 35.9066,
-  longitude: 139.6231
-)
+unless Rails.env.development?
+  puts "Skip seeds (not development)"
+  exit
+end
 
-Toilet.where(station: station).destroy_all
+puts "=== development seed reset ==="
 
-Toilet.create!(
-  station: station,
-  name: "テストトイレ",
-  latitude: 35.9069,
-  longitude: 139.6234,
+Toilet.delete_all
+Station.delete_all
+
+# ---- Station（stationsもlat/lng必須）----
+stations = {
+  shinjuku: Station.create!(
+    operator_name: "JR東日本",
+    name: "新宿",
+    latitude: 35.690921,
+    longitude: 139.700258
+  ),
+  omiya: Station.create!(
+    operator_name: "JR東日本",
+    name: "大宮",
+    latitude: 35.906650,
+    longitude: 139.623260
+  ),
+  tokyo: Station.create!(
+    operator_name: "東京メトロ",
+    name: "東京",
+    latitude: 35.681236,
+    longitude: 139.767125
+  )
+}
+
+# ---- Toilet（12件：設備を散らす / スクロール確認用）----
+base_lat = 35.690900
+base_lng = 139.700200
+
+toilets = []
+
+# 新宿：10件作ってスクロール確認しやすくする
+10.times do |i|
+  toilets << {
+    station: stations[:shinjuku],
+    name: "新宿テストトイレ#{i + 1}",
+    latitude: base_lat + (i * 0.00015),
+    longitude: base_lng + (i * 0.00012),
+    style_type: (i % 3 == 0 ? "japanese" : i % 3 == 1 ? "western" : "both"),
+    is_wheelchair_accessible: (i % 2 == 0),
+    is_ostomate_accessible: (i % 3 == 0),
+    is_baby_friendly: (i % 4 == 0),
+    is_gender_separated: true,       # 共用は廃止方針とのことなので固定でtrue
+    is_multipurpose: (i % 5 == 0),
+    location_note: (i % 3 == 0 ? "改札内・端の方" : nil)
+  }
+end
+
+# 他駅：2件
+toilets << {
+  station: stations[:omiya],
+  name: "大宮 中央改札内トイレ",
+  latitude: 35.906700,
+  longitude: 139.623100,
+  style_type: "western",
   is_wheelchair_accessible: true,
-  is_baby_friendly: true,
   is_ostomate_accessible: false,
-  is_gender_separated: false,
+  is_baby_friendly: true,
+  is_gender_separated: true,
+  is_multipurpose: true,
+  location_note: "改札内"
+}
+
+toilets << {
+  station: stations[:tokyo],
+  name: "東京 地下通路トイレ",
+  latitude: 35.681100,
+  longitude: 139.767300,
+  style_type: "both",
+  is_wheelchair_accessible: false,
+  is_ostomate_accessible: true,
+  is_baby_friendly: false,
+  is_gender_separated: true,
   is_multipurpose: false,
-  style_type: 2
-)
+  location_note: nil
+}
+
+# 保存（落ちたらどれが原因か出す）
+toilets.each_with_index do |t, idx|
+  station = t.delete(:station)
+  toilet = station.toilets.build(t)
+
+  unless toilet.valid?
+    puts "Seed toilet invalid at index=#{idx}: #{t[:name]}"
+    puts toilet.errors.full_messages.inspect
+    puts "attrs=#{t.inspect}"
+    raise "Seed failed"
+  end
+
+  toilet.save!
+end
+
+puts "Seed done: Station=#{Station.count}, Toilet=#{Toilet.count}"
+puts "============================"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,6 @@ puts "=== development seed reset ==="
 Toilet.delete_all
 Station.delete_all
 
-# ---- Station（stationsもlat/lng必須）----
 stations = {
   shinjuku: Station.create!(
     operator_name: "JR東日本",
@@ -33,13 +32,11 @@ stations = {
   )
 }
 
-# ---- Toilet（12件：設備を散らす / スクロール確認用）----
 base_lat = 35.690900
 base_lng = 139.700200
 
 toilets = []
 
-# 新宿：10件作ってスクロール確認しやすくする
 10.times do |i|
   toilets << {
     station: stations[:shinjuku],
@@ -50,13 +47,12 @@ toilets = []
     is_wheelchair_accessible: (i % 2 == 0),
     is_ostomate_accessible: (i % 3 == 0),
     is_baby_friendly: (i % 4 == 0),
-    is_gender_separated: true,       # 共用は廃止方針とのことなので固定でtrue
+    is_gender_separated: true,
     is_multipurpose: (i % 5 == 0),
     location_note: (i % 3 == 0 ? "改札内・端の方" : nil)
   }
 end
 
-# 他駅：2件
 toilets << {
   station: stations[:omiya],
   name: "大宮 中央改札内トイレ",
@@ -85,7 +81,6 @@ toilets << {
   location_note: nil
 }
 
-# 保存（落ちたらどれが原因か出す）
 toilets.each_with_index do |t, idx|
   station = t.delete(:station)
   toilet = station.toilets.build(t)


### PR DESCRIPTION
## 概要
-ログイン前UIの整備と、/search（地図・一覧・モーダル）周りのUI/UX改善を行い、MVPとして一連の導線を確認できる状態にしました。

## 関連issue
Close #40 

### 変更内容
- 共通レイアウト（ヘッダー/フッター）を実装し、スマホはハンバーガーメニュー、PCは横並びメニューに対応
- ヘッダーメニューを「トイレを探す / 新規登録 / ログイン」に変更（新規登録/ログインは準備中のためダミー導線）
- フッターをオーバーレイ表示にし、主要リンク（お問い合わせ/利用規約/プライバシーポリシー）を配置
- トップページ（home）を構成変更（探すボタン、機能紹介エリア、CTAを整理）し、ボタン幅をレスポンシブに整備
- /search の表示文言（緯度経度など）を整理し、表示の邪魔にならないよう調整（再取得ボタン中心で運用）
- トイレ一覧カードの「詳細」ボタンを枠なしに調整
- トイレ詳細モーダルのUI改善（×ボタン右上/枠なし、☆ボタン枠なし、設備カード3列固定寄せ、モーダル内スクロール対応）
- モーダル表示中は背面スクロールを抑止（body に is-modal-open を付与/解除）
- seed データを整備し、候補が増えた状態で一覧スクロール・設備アイコン表示を確認できるようにした

### 確認方法
1. トップページ / にアクセスし、レイアウト（ヘッダー/フッター/ボタン幅）を確認
2. 「探す」から /search に遷移し、現在地取得 → 地図表示を確認
3. トイレ一覧がスクロールできることを確認（地図は固定）
4. 一覧の › ボタン押下でモーダルが開くことを確認
5. モーダル表示中に背面がスクロールしないことを確認
6. モーダルを「×」「背景クリック」「Esc」で閉じられることを確認
7. 位置情報「再取得」ボタンで再検索できることを確認
8. 画面幅（モバイル/PC）を変えて、ヘッダーメニューの切替とハンバーガー動作を確認

## スクリーンショット

![（トップページ：PC/スマホ）](https://i.gyazo.com/7e690d0d588d3bda2dee1b484e5ec6dd.png)
![（/search：地図＋一覧）](https://i.gyazo.com/511d30cb955008352db6196b3ba3c217.png)
![（モーダル表示）](https://i.gyazo.com/5592ff2d2052135fedb902bc48f6adea.png)


## セルフチェックリスト

- [x]  不要なコードやコメントアウトが残っていないか
- [x]  エラーハンドリングは適切か（位置情報エラー時の表示など）
- [x] 実装漏れがないか（レスポンシブ、モーダルclose、スクロール抑止）
