### PR TITLE
Feature/review posting

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -224,7 +224,9 @@
 }
 
 .btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   padding: var(--btn-pad-y) var(--btn-pad-x);
   border-radius: var(--btn-radius);
@@ -234,6 +236,14 @@
   background: #fff;
   font-size: var(--fs-lg);
   line-height: 1.1;
+  box-sizing: border-box;
+}
+
+.btn--sm {
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  min-height: 36px;
 }
 
 .btn--block {
@@ -690,10 +700,34 @@ body.is-modal-open .toilet-modal__backdrop {
 .mobile-menu__logout-btn {
   background: none;
   border: 0;
-  padding: 0;
   font: inherit;
+  color: #111;
   cursor: pointer;
 }
+
+.site-nav__logout-btn {
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.mobile-menu__logout-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 10px;
+  border-radius: 10px;
+}
+
+.site-nav__logout-btn:hover,
+.mobile-menu__logout-btn:hover {
+  background: #f5f5f5;
+}
+
+.site-nav__logout-form,
+.mobile-menu__logout-form {
+  margin: 0;
+}
+
 .site-nav__link--disabled,
 .mobile-menu__link--disabled {
   opacity: 0.5;
@@ -744,10 +778,14 @@ body.is-modal-open .toilet-modal__backdrop {
   font-size: var(--fs-md);
 }
 
+.toilet-modal__reviewHeader .reviews-item__badge {
+  margin-top: 4px;
+}
+
 .toilet-modal__reviewSummary {
   display: grid;
-  gap: 4px;
-  margin-bottom: 10px;
+  gap: 6px;
+  margin-bottom: 12px;
 }
 
 .toilet-modal__reviewAverage,
@@ -764,34 +802,36 @@ body.is-modal-open .toilet-modal__backdrop {
 .toilet-modal__reviewItem {
   border: 1px solid #e5e5e5;
   border-radius: 10px;
-  padding: 10px;
+  padding: 12px;
   background: #fff;
+  display: grid;
+  gap: 8px;
 }
 
 .toilet-modal__reviewHeader {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.toilet-modal__reviewHeader > div:first-child {
+  min-width: 0;
 }
 
 .toilet-modal__reviewUser {
+  display: inline-block;
   font-size: 12px;
   color: #666;
-  word-break: break-all;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .toilet-modal__reviewRating {
   font-weight: 700;
   font-size: 14px;
-}
-
-.toilet-modal__reviewComment {
-  font-size: 14px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .reviews-list {
@@ -808,52 +848,405 @@ body.is-modal-open .toilet-modal__backdrop {
   padding: 14px;
   background: #fff;
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .reviews-item__header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: 10px;
+}
+
+.reviews-item__header > div:first-child {
+  min-width: 0;
 }
 
 .reviews-item__title {
   font-weight: 700;
   font-size: 16px;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .reviews-item__sub {
   font-size: 12px;
   color: #666;
-  margin-top: 4px;
+  margin-top: 2px;
+  word-break: break-word;
 }
 
 .reviews-item__rating {
   font-weight: 700;
   font-size: 16px;
+  line-height: 1.2;
   white-space: nowrap;
 }
 
-.reviews-item__comment {
+.reviews-item__comment,
+.toilet-modal__reviewComment {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.5;
+  text-align: left;
   white-space: pre-wrap;
   word-break: break-word;
+
+  padding: 10px 12px;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  background: #fafafa;
+
+  margin: 0;
+
+  max-height: 7.2em;
+  overflow-y: auto;
+}
+
+.toilet-modal__reviewComment--compact {
+  white-space: nowrap;
+  word-break: normal;
+  overflow: hidden;
+  overflow-y: hidden;
+  text-overflow: ellipsis;
+  max-height: none;
+}
+
+.reviews-item__comment--empty {
+  color: #666;
+  font-style: italic;
 }
 
 .reviews-item__meta {
   font-size: 12px;
   color: #666;
+  line-height: 1.4;
 }
 
 .reviews-item__actions {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: 2px;
+}
+
+.reviews-item__actions form {
+  margin: 0;
+}
+
+.reviews-item__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  box-sizing: border-box;
 }
 
 .mypage-menu {
   display: grid;
   gap: 12px;
+}
+
+.review-form-card {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.review-form-card__title {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.review-form-card__sub {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #666;
+}
+
+.review-summary-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.review-summary-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid #e5e5e5;
+  border-radius: 999px;
+  background: #fafafa;
+  font-size: 13px;
+  color: #444;
+}
+
+.review-summary-badge--rating {
+  background: #fffdf7;
+}
+
+.review-summary-badge--count {
+  background: #f8f8f8;
+}
+
+.review-summary-badge__label {
+  font-weight: 600;
+  color: #333;
+}
+
+.review-stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.review-stars__visual {
+  letter-spacing: 1px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.review-stars__score {
+  font-weight: 600;
+  color: #111;
+}
+
+.reviews-item--own {
+  border-color: #d8e7ff;
+  background: #fcfdff;
+}
+
+.reviews-item__badge {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #eef4ff;
+  color: #2457a6;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+@media (max-width: 480px) {
+  .review-summary-badges {
+    align-items: flex-start;
+  }
+
+  .review-summary-badge {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+.form-group {
+  display: grid;
+  gap: 8px;
+}
+
+.form-label {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.form-label__optional {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #f2f2f2;
+  color: #666;
+  font-size: 11px;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.form-help {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #666;
+}
+
+.form-select,
+.form-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  background: #fff;
+}
+
+.form-select:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #9bb8ff;
+  box-shadow: 0 0 0 3px rgba(155, 184, 255, 0.2);
+}
+
+.form-textarea {
+  resize: vertical;
+  line-height: 1.5;
+  min-height: 140px;
+}
+
+.review-form-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.review-form-actions .btn,
+.review-form-actions input[type="submit"],
+.review-form-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  box-sizing: border-box;
+}
+
+.review-form-actions input[type="submit"],
+.review-form-actions button {
+  border-radius: var(--btn-radius);
+  border: 1px solid #111;
+  background: #111;
+  color: #fff;
+  font-size: var(--fs-lg);
+  line-height: 1.1;
+  padding: var(--btn-pad-y) var(--btn-pad-x);
+  cursor: pointer;
+}
+
+.review-form-actions a.btn {
+  text-decoration: none;
+}
+
+.form-errors {
+  border: 1px solid #ffd6d6;
+  background: #fff5f5;
+  border-radius: 10px;
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.form-errors__title {
+  margin: 0;
+  font-weight: 700;
+  color: #b00020;
+}
+
+.form-errors__list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.toilet-modal__reviewActions {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.toilet-modal__reviewActions .btn {
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+.toilet-modal__reviewActionHint {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #666;
+}
+
+.btn--danger {
+  background: #e54848;
+  color: white;
+  border: none;
+}
+
+.btn--danger:hover {
+  background: #c13c3c;
+}
+
+.toilet-reviews-summary {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.toilet-reviews-summary__title {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.toilet-reviews-summary__sub {
+  font-size: 12px;
+  color: #666;
+}
+
+.toilet-reviews-summary__meta {
+  font-size: 13px;
+  color: #444;
+}
+
+.toilet-reviews-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.empty-state-card {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.empty-state-card__title {
+  font-weight: 700;
+  font-size: 16px;
+  color: #111;
+}
+
+.empty-state-card__text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #444;
+}
+
+.empty-state-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.empty-state-card__hint {
+  font-size: 13px;
+  color: #666;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -743,3 +743,117 @@ body.is-modal-open .toilet-modal__backdrop {
   padding: 10px 12px; /* 好みで微調整 */
   font-size: var(--fs-md);
 }
+
+.toilet-modal__reviewSummary {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.toilet-modal__reviewAverage,
+.toilet-modal__reviewCount {
+  font-size: 13px;
+  color: #444;
+}
+
+.toilet-modal__reviewList {
+  display: grid;
+  gap: 10px;
+}
+
+.toilet-modal__reviewItem {
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 10px;
+  background: #fff;
+}
+
+.toilet-modal__reviewHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.toilet-modal__reviewUser {
+  font-size: 12px;
+  color: #666;
+  word-break: break-all;
+}
+
+.toilet-modal__reviewRating {
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.toilet-modal__reviewComment {
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.reviews-list {
+  display: grid;
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.reviews-item {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 14px;
+  background: #fff;
+  display: grid;
+  gap: 10px;
+}
+
+.reviews-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.reviews-item__title {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.reviews-item__sub {
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+}
+
+.reviews-item__rating {
+  font-weight: 700;
+  font-size: 16px;
+  white-space: nowrap;
+}
+
+.reviews-item__comment {
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.reviews-item__meta {
+  font-size: 12px;
+  color: #666;
+}
+
+.reviews-item__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.mypage-menu {
+  display: grid;
+  gap: 12px;
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,4 @@
+class MypagesController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,0 +1,7 @@
+class ReviewsController < ApplicationController
+  def index
+    @reviews = current_user.reviews
+      .includes(toilet: :station)
+      .order(created_at: :desc)
+  end
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,7 +1,35 @@
 class ReviewsController < ApplicationController
+  before_action :set_review, only: [ :edit, :update, :destroy ]
+
   def index
     @reviews = current_user.reviews
       .includes(toilet: :station)
       .order(created_at: :desc)
+  end
+
+  def edit
+  end
+
+  def update
+    if @review.update(review_params)
+      redirect_to reviews_path, notice: "レビューを更新しました"
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @review.destroy
+    redirect_to reviews_path, notice: "レビューを削除しました"
+  end
+
+  private
+
+  def set_review
+    @review = current_user.reviews.includes(toilet: :station).find(params[:id])
+  end
+
+  def review_params
+    params.require(:review).permit(:rating, :comment)
   end
 end

--- a/app/controllers/toilet_favorites_controller.rb
+++ b/app/controllers/toilet_favorites_controller.rb
@@ -1,0 +1,22 @@
+class ToiletFavoritesController < ApplicationController
+  def create
+    toilet = Toilet.find(params[:toilet_id])
+
+    favorite = current_user.favorites.find_or_initialize_by(toilet: toilet)
+
+    if favorite.persisted? || favorite.save
+      render json: { favorited: true }, status: :ok
+    else
+      render json: { errors: favorite.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    toilet = Toilet.find(params[:toilet_id])
+
+    favorite = current_user.favorites.find_by(toilet: toilet)
+    favorite&.destroy
+
+    render json: { favorited: false }, status: :ok
+  end
+end

--- a/app/controllers/toilet_reviews_controller.rb
+++ b/app/controllers/toilet_reviews_controller.rb
@@ -1,0 +1,25 @@
+class ToiletReviewsController < ApplicationController
+  def create
+    toilet = Toilet.find(params[:toilet_id])
+    review = current_user.reviews.build(review_params)
+    review.toilet = toilet
+
+    if review.save
+      render json: {
+        id: review.id,
+        rating: review.rating,
+        comment: review.comment.to_s
+      }, status: :created
+    else
+      render json: {
+        errors: review.errors.full_messages
+      }, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def review_params
+    params.require(:review).permit(:rating, :comment)
+  end
+end

--- a/app/controllers/toilet_reviews_controller.rb
+++ b/app/controllers/toilet_reviews_controller.rb
@@ -1,19 +1,51 @@
 class ToiletReviewsController < ApplicationController
-  def create
-    toilet = Toilet.find(params[:toilet_id])
-    review = current_user.reviews.build(review_params)
-    review.toilet = toilet
+  allow_unauthenticated_access only: [ :index ]
 
-    if review.save
-      render json: {
-        id: review.id,
-        rating: review.rating,
-        comment: review.comment.to_s
-      }, status: :created
-    else
-      render json: {
-        errors: review.errors.full_messages
-      }, status: :unprocessable_content
+  def index
+    @toilet = Toilet.includes(:station, reviews: :user).find(params[:toilet_id])
+    @reviews = @toilet.reviews.includes(:user).order(created_at: :desc)
+
+    @average_rating =
+      if @reviews.any?
+        @reviews.average(:rating).to_f.round(1)
+      end
+  end
+
+  def new
+    @toilet = Toilet.includes(:station).find(params[:toilet_id])
+
+    existing_review = current_user.reviews.find_by(toilet: @toilet)
+    if existing_review
+      redirect_to reviews_path, alert: "このトイレにはすでにレビューを投稿しています"
+      return
+    end
+
+    @review = current_user.reviews.build(toilet: @toilet)
+  end
+
+  def create
+    @toilet = Toilet.find(params[:toilet_id])
+    @review = current_user.reviews.build(review_params)
+    @review.toilet = @toilet
+
+    respond_to do |format|
+      if @review.save
+        format.html { redirect_to reviews_path, notice: "レビューを投稿しました" }
+        format.json do
+          render json: {
+            id: @review.id,
+            rating: @review.rating,
+            comment: @review.comment.to_s
+          }, status: :created
+        end
+      else
+        format.html { render :new, status: :unprocessable_content }
+        format.json do
+          render json: {
+            errors: @review.errors.full_messages
+          }, status: :unprocessable_content
+        end
+      end
     end
   end
 

--- a/app/controllers/toilets_controller.rb
+++ b/app/controllers/toilets_controller.rb
@@ -9,7 +9,7 @@ class ToiletsController < ApplicationController
   end
 
   def show
-    toilet = Toilet.includes(:station).find(params[:id])
+    toilet = Toilet.includes(reviews: :user, station: []).find(params[:id])
 
     render json: build_toilet_json(toilet), status: :ok
   end
@@ -36,11 +36,19 @@ class ToiletsController < ApplicationController
         if favorited_ids
           favorited_ids.include?(toilet.id)
         else
-          # ✅ show 単体でも安全に判定できるように
           ::Favorite.exists?(user_id: current_user.id, toilet_id: toilet.id)
         end
       else
         false
+      end
+
+    reviews = toilet.reviews.includes(:user).order(created_at: :desc)
+
+    average_rating =
+      if reviews.any?
+        (reviews.average(:rating).to_f.round(1))
+      else
+        nil
       end
 
     {
@@ -53,7 +61,7 @@ class ToiletsController < ApplicationController
       is_baby_friendly: toilet.is_baby_friendly,
       is_multipurpose: toilet.is_multipurpose,
       is_wheelchair_accessible: toilet.is_wheelchair_accessible,
-      is_ostomate_accessible: toilet.is_ostomate_accessible, # ←抜け防止
+      is_ostomate_accessible: toilet.is_ostomate_accessible,
       is_gender_separated: toilet.is_gender_separated,
       location_note: toilet.location_note,
       favorited: favorited,
@@ -61,7 +69,23 @@ class ToiletsController < ApplicationController
         id: toilet.station&.id,
         name: toilet.station&.name,
         operator_name: toilet.station&.operator_name
-      }
+      },
+      review_summary: {
+        average_rating: average_rating,
+        review_count: reviews.size
+      },
+      reviews: reviews.map do |review|
+        {
+          id: review.id,
+          rating: review.rating,
+          comment: review.comment.to_s,
+          created_at: review.created_at,
+          user: {
+            id: review.user.id,
+            email_address: review.user.email_address
+          }
+        }
+      end
     }
   end
 end

--- a/app/controllers/toilets_controller.rb
+++ b/app/controllers/toilets_controller.rb
@@ -1,7 +1,7 @@
 require "set"
 
 class ToiletsController < ApplicationController
-  allow_unauthenticated_access only: %i[index show]
+  allow_unauthenticated_access only: %i[ index show ]
 
   def index
     toilets = Toilet.includes(:station).order(:id)
@@ -9,7 +9,7 @@ class ToiletsController < ApplicationController
   end
 
   def show
-    toilet = Toilet.includes(reviews: :user, station: []).find(params[:id])
+    toilet = Toilet.includes(:station, reviews: :user).find(params[:id])
 
     render json: build_toilet_json(toilet), status: :ok
   end
@@ -19,7 +19,6 @@ class ToiletsController < ApplicationController
   def build_payload(toilets)
     favorited_ids =
       if current_user
-        # ✅ 名前空間問題を避けるため ::Favorite に固定
         ::Favorite.where(user_id: current_user.id).pluck(:toilet_id).to_set
       else
         Set.new
@@ -46,9 +45,12 @@ class ToiletsController < ApplicationController
 
     average_rating =
       if reviews.any?
-        (reviews.average(:rating).to_f.round(1))
-      else
-        nil
+        reviews.average(:rating).to_f.round(1)
+      end
+
+    current_user_review =
+      if current_user
+        reviews.find { |review| review.user_id == current_user.id }
       end
 
     {
@@ -74,6 +76,11 @@ class ToiletsController < ApplicationController
         average_rating: average_rating,
         review_count: reviews.size
       },
+      current_user_review: current_user_review ? {
+        id: current_user_review.id,
+        rating: current_user_review.rating,
+        comment: current_user_review.comment.to_s
+      } : nil,
       reviews: reviews.map do |review|
         {
           id: review.id,
@@ -81,8 +88,8 @@ class ToiletsController < ApplicationController
           comment: review.comment.to_s,
           created_at: review.created_at,
           user: {
-            id: review.user.id,
-            email_address: review.user.email_address
+            id: review.user&.id,
+            display_name: review.user&.display_name.presence || "no name"
           }
         }
       end

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -294,6 +294,12 @@ function escapeHtml(str) {
   });
 }
 
+function truncateText(text, maxLength = 48) {
+  const normalized = String(text || "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}…`;
+}
+
 function markOrUnknown(value) {
   if (value === true) return "〇";
   if (value === false) return "×";
@@ -402,6 +408,7 @@ function openToiletModal(toilet) {
 
   const loggedIn = isLoggedIn();
   const favorited = toilet.favorited === true;
+  const currentUserReview = toilet.current_user_review;
 
   const wheelchair = toilet.is_wheelchair_accessible ? "〇" : "×";
   const ostomate   = toilet.is_ostomate_accessible ? "〇" : "×";
@@ -499,7 +506,33 @@ function openToiletModal(toilet) {
 
     <div class="toilet-modal__section">
       <div class="toilet-modal__sectionTitle">レビュー</div>
+
       ${buildReviewsHtml(toilet)}
+
+      ${
+        loggedIn
+          ? `<div class="toilet-modal__reviewActions">
+              ${
+                currentUserReview
+                  ? `<a href="/reviews/${currentUserReview.id}/edit"
+                        class="btn btn--secondary">
+                      レビューを編集する
+                    </a>`
+                  : `<a href="/toilets/${toilet.id}/reviews/new"
+                        class="btn btn--secondary">
+                      レビューを書く
+                    </a>`
+              }
+
+              <a href="/toilets/${toilet.id}/reviews"
+                class="btn btn--secondary">
+                レビュー一覧を見る
+              </a>
+            </div>`
+          : `<div class="toilet-modal__reviewActionHint">
+              レビューを書くにはログインしてください
+            </div>`
+      }
     </div>
 
     <button
@@ -522,17 +555,40 @@ function openToiletModal(toilet) {
 function buildReviewsHtml(toilet) {
   const reviewSummary = toilet.review_summary || {};
   const reviews = Array.isArray(toilet.reviews) ? toilet.reviews : [];
+  const currentUserReviewId = toilet.current_user_review?.id || null;
 
-  const averageRating =
-    reviewSummary.average_rating == null ? "未評価" : `${reviewSummary.average_rating} / 5`;
+  const averageRatingValue = reviewSummary.average_rating;
   const reviewCount = reviewSummary.review_count || 0;
 
-  const summaryHtml = `
-    <div class="toilet-modal__reviewSummary">
-      <div class="toilet-modal__reviewAverage">平均評価: ${escapeHtml(String(averageRating))}</div>
-      <div class="toilet-modal__reviewCount">レビュー件数: ${reviewCount}件</div>
-    </div>
-  `;
+  const summaryHtml = averageRatingValue == null
+    ? `
+      <div class="toilet-modal__reviewSummary">
+        <div class="review-summary-badges">
+          <span class="review-summary-badge review-summary-badge--rating">
+            平均評価 未評価
+          </span>
+          <span class="review-summary-badge review-summary-badge--count">
+            レビュー ${reviewCount}件
+          </span>
+        </div>
+      </div>
+    `
+    : `
+      <div class="toilet-modal__reviewSummary">
+        <div class="review-summary-badges">
+          <span class="review-summary-badge review-summary-badge--rating">
+            <span class="review-summary-badge__label">平均評価</span>
+            <span class="review-stars" aria-label="平均評価 ${escapeHtml(String(averageRatingValue))} / 5">
+              <span class="review-stars__visual">${"★".repeat(Math.round(Number(averageRatingValue)))}${"☆".repeat(5 - Math.round(Number(averageRatingValue)))}</span>
+              <span class="review-stars__score">${escapeHtml(String(averageRatingValue))} / 5</span>
+            </span>
+          </span>
+          <span class="review-summary-badge review-summary-badge--count">
+            レビュー ${reviewCount}件
+          </span>
+        </div>
+      </div>
+    `;
 
   if (reviews.length === 0) {
     return `
@@ -542,16 +598,21 @@ function buildReviewsHtml(toilet) {
   }
 
   const itemsHtml = reviews.map((review) => {
-    const email = review.user?.email_address || "ユーザー";
-    const comment = review.comment?.trim() ? review.comment : "コメントなし";
+    const displayName = review.user?.display_name || "no name";
+    const rawComment = review.comment?.trim() ? review.comment : "コメントなし";
+    const comment = truncateText(rawComment, 48);
+    const isOwnReview = currentUserReviewId && Number(review.id) === Number(currentUserReviewId);
 
     return `
-      <div class="toilet-modal__reviewItem">
+      <div class="toilet-modal__reviewItem ${isOwnReview ? "reviews-item--own" : ""}">
         <div class="toilet-modal__reviewHeader">
-          <span class="toilet-modal__reviewUser">${escapeHtml(email)}</span>
+          <div>
+            <span class="toilet-modal__reviewUser">${escapeHtml(displayName)}</span>
+            ${isOwnReview ? `<div class="reviews-item__badge">あなたのレビュー</div>` : ""}
+          </div>
           <span class="toilet-modal__reviewRating">★${escapeHtml(String(review.rating))}</span>
         </div>
-        <div class="toilet-modal__reviewComment">${escapeHtml(comment)}</div>
+        <div class="toilet-modal__reviewComment toilet-modal__reviewComment--compact">${escapeHtml(comment)}</div>
       </div>
     `;
   }).join("");
@@ -616,91 +677,102 @@ async function openToiletModalById(toiletId) {
 document.addEventListener("turbo:load", () => {
   setupGeolocationButton();
   setupToiletModalCloseEvents();
-  setupToiletModalDelegationOnce(); // ✅ 追加
+  setupToiletModalDelegationOnce();
+  setupOpenToiletModalDelegationOnce();
   setupFavoritesIndexBindings();
 });
 
+function setupOpenToiletModalDelegationOnce() {
+  if (document.documentElement.dataset.openToiletModalBound === "true") return;
+  document.documentElement.dataset.openToiletModalBound = "true";
+
+  document.addEventListener("click", async (e) => {
+    const openBtn = e.target.closest('[data-open-toilet-modal="true"]');
+    if (!openBtn) return;
+
+    const toiletId = openBtn.dataset.toiletId;
+    if (!toiletId) return;
+
+    if (openBtn.dataset.busy === "true") return;
+    openBtn.dataset.busy = "true";
+    openBtn.disabled = true;
+
+    try {
+      e.preventDefault();
+      await openToiletModalById(toiletId);
+    } finally {
+      openBtn.dataset.busy = "false";
+      openBtn.disabled = false;
+    }
+  });
+}
+
 function setupFavoritesIndexBindings() {
-  // favoritesページにいないなら何もしない（他ページに影響させない）
   const root = document.querySelector('[data-favorites-root="true"]');
   if (!root) return;
 
-  // Turbo再訪でも多重登録しない
   if (document.documentElement.dataset.favoritesIndexBound === "true") return;
   document.documentElement.dataset.favoritesIndexBound = "true";
 
   document.addEventListener("click", async (e) => {
-    // 1) トイレ名クリック → モーダルを開く
-    const openBtn = e.target.closest('[data-open-toilet-modal="true"]');
-    if (openBtn) {
-      const toiletId = openBtn.dataset.toiletId;
-      if (!toiletId) return;
-      e.preventDefault();
-      await openToiletModalById(toiletId);
-      return;
-    }
-
-    // 2) 解除クリック → DELETE → 行削除 → 同期イベント
     const unfavBtn = e.target.closest('[data-favorites-unfavorite="true"]');
-    if (unfavBtn) {
-      const toiletId = unfavBtn.dataset.toiletId;
-      if (!toiletId) return;
+    if (!unfavBtn) return;
 
-      unfavBtn.disabled = true;
+    const toiletId = unfavBtn.dataset.toiletId;
+    if (!toiletId) return;
 
-      try {
-        const res = await fetch(`/toilets/${toiletId}/favorite`, {
-          method: "DELETE",
-          credentials: "same-origin",
-          headers: {
-            "Accept": "application/json",
-            "X-CSRF-Token": csrfToken() || "",
-          },
-        });
+    unfavBtn.disabled = true;
 
-        if (res.status === 401) {
-          alert("ログインしてください");
-          window.location.href = "/session/new";
-          return;
-        }
+    try {
+      const res = await fetch(`/toilets/${toiletId}/favorite`, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: {
+          "Accept": "application/json",
+          "X-CSRF-Token": csrfToken() || "",
+        },
+      });
 
-        if (!res.ok) {
-          alert("お気に入りの更新に失敗しました");
-          unfavBtn.disabled = false;
-          return;
-        }
-
-        const data = await res.json(); // { favorited: false } 想定
-
-        const nearestItem = unfavBtn.closest('[data-favorites-item="true"]');
-        if (nearestItem) {
-          nearestItem.remove();
-        } else {
-           // 2) 保険：rootの中からID一致で探して消す（空白なし・確実）
-          const selector = `[data-favorites-item="true"][data-toilet-id="${CSS.escape(String(toiletId))}"]`;
-          const item = root.querySelector(selector);
-          if (item) item.remove(); 
-        }
-
-        if (root.querySelectorAll('[data-favorites-item="true"]').length === 0) {
-          const container = root.parentElement; // ulの親（elseブロック内の領域）を想定
-          if (container) {
-            container.innerHTML = `
-              <p>お気に入りはまだありません。</p>
-              <a class="btn btn--primary" href="/search">トイレを探す</a>
-            `;
-          }
-        }
-
-        // モーダルや他UIへ同期通知
-        window.dispatchEvent(new CustomEvent("toilet:favorited-changed", {
-          detail: { toiletId: String(toiletId), favorited: Boolean(data.favorited) }
-        }));
-        } catch (err) {
-        console.error(err);
-        alert("通信エラーが発生しました");
-        unfavBtn.disabled = false;
+      if (res.status === 401) {
+        alert("ログインしてください");
+        window.location.href = "/session/new";
+        return;
       }
+
+      if (!res.ok) {
+        alert("お気に入りの更新に失敗しました");
+        unfavBtn.disabled = false;
+        return;
+      }
+
+      const data = await res.json();
+
+      const nearestItem = unfavBtn.closest('[data-favorites-item="true"]');
+      if (nearestItem) {
+        nearestItem.remove();
+      } else {
+        const selector = `[data-favorites-item="true"][data-toilet-id="${CSS.escape(String(toiletId))}"]`;
+        const item = root.querySelector(selector);
+        if (item) item.remove();
+      }
+
+      if (root.querySelectorAll('[data-favorites-item="true"]').length === 0) {
+        const container = root.parentElement;
+        if (container) {
+          container.innerHTML = `
+            <p>お気に入りはまだありません。</p>
+            <a class="btn btn--primary" href="/search">トイレを探す</a>
+          `;
+        }
+      }
+
+      window.dispatchEvent(new CustomEvent("toilet:favorited-changed", {
+        detail: { toiletId: String(toiletId), favorited: Boolean(data.favorited) }
+      }));
+    } catch (err) {
+      console.error(err);
+      alert("通信エラーが発生しました");
+      unfavBtn.disabled = false;
     }
   });
 }

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -498,13 +498,8 @@ function openToiletModal(toilet) {
     </div>
 
     <div class="toilet-modal__section">
-      <div class="toilet-modal__sectionTitle">評価（将来）</div>
-      <div class="toilet-modal__placeholder">評価エリア（将来）</div>
-    </div>
-
-    <div class="toilet-modal__section">
-      <div class="toilet-modal__sectionTitle">コメント（将来）</div>
-      <div class="toilet-modal__placeholder">コメント表示（将来）</div>
+      <div class="toilet-modal__sectionTitle">レビュー</div>
+      ${buildReviewsHtml(toilet)}
     </div>
 
     <button
@@ -522,6 +517,51 @@ function openToiletModal(toilet) {
   modal.setAttribute("aria-hidden", "false");
 
   document.body.classList.add("is-modal-open");
+}
+
+function buildReviewsHtml(toilet) {
+  const reviewSummary = toilet.review_summary || {};
+  const reviews = Array.isArray(toilet.reviews) ? toilet.reviews : [];
+
+  const averageRating =
+    reviewSummary.average_rating == null ? "未評価" : `${reviewSummary.average_rating} / 5`;
+  const reviewCount = reviewSummary.review_count || 0;
+
+  const summaryHtml = `
+    <div class="toilet-modal__reviewSummary">
+      <div class="toilet-modal__reviewAverage">平均評価: ${escapeHtml(String(averageRating))}</div>
+      <div class="toilet-modal__reviewCount">レビュー件数: ${reviewCount}件</div>
+    </div>
+  `;
+
+  if (reviews.length === 0) {
+    return `
+      ${summaryHtml}
+      <div class="toilet-modal__placeholder">レビューはまだありません</div>
+    `;
+  }
+
+  const itemsHtml = reviews.map((review) => {
+    const email = review.user?.email_address || "ユーザー";
+    const comment = review.comment?.trim() ? review.comment : "コメントなし";
+
+    return `
+      <div class="toilet-modal__reviewItem">
+        <div class="toilet-modal__reviewHeader">
+          <span class="toilet-modal__reviewUser">${escapeHtml(email)}</span>
+          <span class="toilet-modal__reviewRating">★${escapeHtml(String(review.rating))}</span>
+        </div>
+        <div class="toilet-modal__reviewComment">${escapeHtml(comment)}</div>
+      </div>
+    `;
+  }).join("");
+
+  return `
+    ${summaryHtml}
+    <div class="toilet-modal__reviewList">
+      ${itemsHtml}
+    </div>
+  `;
 }
 
 function setupToiletModalDelegationOnce() {

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,8 @@
+class Review < ApplicationRecord
+  belongs_to :user
+  belongs_to :toilet
+
+  validates :rating, presence: true, inclusion: { in: 1..5 }
+  validates :comment, length: { maximum: 500 }, allow_blank: true
+  validates :user_id, uniqueness: { scope: :toilet_id }
+end

--- a/app/models/toilet.rb
+++ b/app/models/toilet.rb
@@ -1,8 +1,11 @@
 class Toilet < ApplicationRecord
   belongs_to :station
+
   has_many :favorites, dependent: :destroy
   has_many :favorited_users, through: :favorites, source: :user
 
+  has_many :reviews, dependent: :destroy
+  has_many :reviewing_users, through: :reviews, source: :user
 
   enum :style_type, { japanese: 0, western: 1, both: 2 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   before_create :set_email_confirmation_token
 
+  validates :display_name, length: { maximum: 30 }, allow_blank: true
+
   def email_confirmed?
     email_confirmed_at.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_toilets, through: :favorites, source: :toilet
 
+  has_many :reviews, dependent: :destroy
+  has_many :reviewed_toilets, through: :reviews, source: :toilet
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   before_create :set_email_confirmation_token
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
           <% if respond_to?(:authenticated?) && authenticated? %>
             <%= link_to "お気に入り", favorites_path, class: "site-nav__link" %>
             <span class="site-nav__link site-nav__link--disabled">通勤・通学ルート（準備中）</span>
+            <%= link_to "評価・投稿一覧", reviews_path, class: "site-nav__link" %>
             <span class="site-nav__link site-nav__link--disabled">評価・投稿一覧（準備中）</span>
             <span class="site-nav__link site-nav__link--disabled">マイページ（準備中）</span>
 
@@ -76,6 +77,7 @@
           <% if authenticated? %>
             <%= link_to "お気に入り", favorites_path, class: "site-nav__link" %>
             <span class="mobile-menu__link mobile-menu__link--disabled">通勤・通学ルート（準備中）</span>
+            <%= link_to "評価・投稿一覧", reviews_path, class: "mobile-menu__link" %>
             <span class="mobile-menu__link mobile-menu__link--disabled">評価・投稿一覧（準備中）</span>
             <span class="mobile-menu__link mobile-menu__link--disabled">マイページ（準備中）</span>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,7 +75,7 @@
             <%= link_to "トイレを探す", search_path, class: "mobile-menu__link" %>
 
           <% if authenticated? %>
-            <%= link_to "お気に入り", favorites_path, class: "site-nav__link" %>
+            <%= link_to "お気に入り", favorites_path, class: "mobile-menu__link" %>
             <span class="mobile-menu__link mobile-menu__link--disabled">通勤・通学ルート（準備中）</span>
             <%= link_to "評価・投稿一覧", reviews_path, class: "mobile-menu__link" %>
             <span class="mobile-menu__link mobile-menu__link--disabled">評価・投稿一覧（準備中）</span>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,6 @@
+<h1 class="page-title">マイページ</h1>
+
+<div class="mypage-menu">
+  <%= link_to "お気に入り一覧", favorites_path, class: "btn btn--primary btn--block" %>
+  <%= link_to "レビュー一覧", reviews_path, class: "btn btn--secondary btn--block" %>
+</div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,51 @@
+<h1 class="page-title">レビューを編集</h1>
+
+<div class="review-form-card">
+  <div class="review-form-card__toilet">
+    <div class="review-form-card__title"><%= @review.toilet.name %></div>
+
+    <% if @review.toilet.station %>
+      <div class="review-form-card__sub">
+        <%= @review.toilet.station.operator_name %> / <%= @review.toilet.station.name %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= form_with model: @review, url: review_path(@review), method: :patch, local: true do |f| %>
+    <% if @review.errors.any? %>
+      <div class="form-errors">
+        <p class="form-errors__title">入力内容を確認してください</p>
+        <ul class="form-errors__list">
+          <% @review.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="form-group">
+      <%= f.label :rating, "評価", class: "form-label" %>
+      <div class="form-help">1が低め、5が高評価です。</div>
+      <%= f.select :rating,
+          options_for_select(1..5, @review.rating),
+          { include_blank: "選択してください" },
+          class: "form-select" %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :comment, class: "form-label" do %>
+        コメント <span class="form-label__optional">任意</span>
+      <% end %>
+      <div class="form-help">使いやすさや気づいたことがあれば入力してください。</div>
+      <%= f.text_area :comment,
+          rows: 5,
+          class: "form-textarea",
+          placeholder: "使いやすさや気づいたことがあれば入力してください" %>
+    </div>
+
+    <div class="review-form-actions">
+      <%= link_to "戻る", reviews_path, class: "btn btn--secondary" %>
+      <%= f.submit "レビューを更新する", class: "btn btn--primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,14 +1,21 @@
-<h1 class="page-title">自分のレビュー一覧</h1>
+<h1 class="page-title">評価・投稿一覧</h1>
 
 <% if @reviews.empty? %>
-  <p>まだレビューはありません。</p>
-  <%= link_to "トイレを探す", search_path, class: "btn btn--primary" %>
+  <div class="empty-state-card">
+    <div class="empty-state-card__title">まだレビューはありません</div>
+    <div class="empty-state-card__text">
+      トイレを探してレビューを投稿すると、あとから自分の投稿を見返せます。
+    </div>
+    <div class="empty-state-card__actions">
+      <%= link_to "トイレを探す", search_path, class: "btn btn--primary btn--sm" %>
+    </div>
+  </div>
 <% else %>
   <ul class="reviews-list">
     <% @reviews.each do |review| %>
       <% toilet = review.toilet %>
 
-      <li class="reviews-item">
+      <li class="reviews-item reviews-item--own">
         <div class="reviews-item__header">
           <div>
             <div class="reviews-item__title">
@@ -20,6 +27,8 @@
                 <%= toilet.station.operator_name %> / <%= toilet.station.name %>
               </div>
             <% end %>
+
+            <div class="reviews-item__badge">あなたのレビュー</div>
           </div>
 
           <div class="reviews-item__rating">
@@ -27,16 +36,24 @@
           </div>
         </div>
 
-        <div class="reviews-item__comment">
-          <%= review.comment.present? ? review.comment : "コメントなし" %>
-        </div>
+        <div class="reviews-item__comment <%= "reviews-item__comment--empty" unless review.comment.present? %>"><%= review.comment.present? ? review.comment : "コメントなし" %></div>
 
         <div class="reviews-item__meta">
-          投稿日: <%= l(review.created_at, format: :short) %>
+          投稿日: <%= review.created_at.strftime("%Y/%m/%d %H:%M") %>
         </div>
 
         <div class="reviews-item__actions">
-          <%= link_to "トイレ詳細を見る", search_path, class: "btn btn--secondary" %>
+          <%= link_to "編集", edit_review_path(review), class: "btn btn--secondary btn--sm" %>
+          <%= button_to "削除", review_path(review), method: :delete, data: { confirm: "このレビューを削除しますか？" }, class: "btn btn--danger btn--sm" %>
+
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            data-open-toilet-modal="true"
+            data-toilet-id="<%= review.toilet.id %>"
+          >
+            トイレを表示する
+          </button>
         </div>
       </li>
     <% end %>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,0 +1,44 @@
+<h1 class="page-title">自分のレビュー一覧</h1>
+
+<% if @reviews.empty? %>
+  <p>まだレビューはありません。</p>
+  <%= link_to "トイレを探す", search_path, class: "btn btn--primary" %>
+<% else %>
+  <ul class="reviews-list">
+    <% @reviews.each do |review| %>
+      <% toilet = review.toilet %>
+
+      <li class="reviews-item">
+        <div class="reviews-item__header">
+          <div>
+            <div class="reviews-item__title">
+              <%= toilet.name %>
+            </div>
+
+            <% if toilet.station %>
+              <div class="reviews-item__sub">
+                <%= toilet.station.operator_name %> / <%= toilet.station.name %>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="reviews-item__rating">
+            ★ <%= review.rating %>
+          </div>
+        </div>
+
+        <div class="reviews-item__comment">
+          <%= review.comment.present? ? review.comment : "コメントなし" %>
+        </div>
+
+        <div class="reviews-item__meta">
+          投稿日: <%= l(review.created_at, format: :short) %>
+        </div>
+
+        <div class="reviews-item__actions">
+          <%= link_to "トイレ詳細を見る", search_path, class: "btn btn--secondary" %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/toilet_reviews/index.html.erb
+++ b/app/views/toilet_reviews/index.html.erb
@@ -1,0 +1,110 @@
+<h1 class="page-title">レビュー一覧</h1>
+
+<% own_review = authenticated? ? current_user.reviews.find_by(toilet: @toilet) : nil %>
+
+<div class="toilet-reviews-summary">
+  <div class="toilet-reviews-summary__title"><%= @toilet.name %></div>
+
+  <% if @toilet.station %>
+    <div class="toilet-reviews-summary__sub">
+      <%= @toilet.station.operator_name %> / <%= @toilet.station.name %>
+    </div>
+  <% end %>
+
+  <div class="toilet-reviews-summary__meta">
+    <% if @average_rating.present? %>
+      <% rounded_average = @average_rating.round %>
+
+      <div class="review-summary-badges">
+        <span class="review-summary-badge review-summary-badge--rating">
+          <span class="review-summary-badge__label">平均評価</span>
+          <span class="review-stars" aria-label="平均評価 <%= @average_rating %> / 5">
+            <span class="review-stars__visual">
+              <%= "★" * rounded_average %><%= "☆" * (5 - rounded_average) %>
+            </span>
+            <span class="review-stars__score"><%= @average_rating %> / 5</span>
+          </span>
+        </span>
+
+        <span class="review-summary-badge review-summary-badge--count">
+          レビュー <%= @reviews.size %>件
+        </span>
+      </div>
+    <% else %>
+      <div class="review-summary-badges">
+        <span class="review-summary-badge review-summary-badge--rating">
+          平均評価 未評価
+        </span>
+
+        <span class="review-summary-badge review-summary-badge--count">
+          レビュー <%= @reviews.size %>件
+        </span>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if @reviews.empty? %>
+  <div class="empty-state-card">
+    <div class="empty-state-card__title">このトイレにはまだレビューがありません</div>
+    <div class="empty-state-card__text">
+      実際に利用した感想を投稿すると、他のユーザーの参考になります。
+    </div>
+
+    <div class="empty-state-card__actions">
+      <% if authenticated? %>
+        <% if own_review %>
+          <%= link_to "レビューを編集する", edit_review_path(own_review), class: "btn btn--primary btn--sm" %>
+        <% else %>
+          <%= link_to "最初のレビューを書く", new_toilet_review_path(@toilet), class: "btn btn--primary btn--sm" %>
+        <% end %>
+      <% else %>
+        <div class="empty-state-card__hint">
+          レビューを書くにはログインが必要です。
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <ul class="reviews-list">
+    <% @reviews.each do |review| %>
+      <% own_review_item = authenticated? && review.user_id == current_user.id %>
+
+      <li class="reviews-item <%= "reviews-item--own" if own_review_item %>">
+        <div class="reviews-item__header">
+          <div>
+            <div class="reviews-item__title">
+              <%= review.user&.display_name.presence || "no name" %>
+            </div>
+
+            <% if own_review_item %>
+              <div class="reviews-item__badge">あなたのレビュー</div>
+            <% end %>
+          </div>
+
+          <div class="reviews-item__rating">
+            ★ <%= review.rating %>
+          </div>
+        </div>
+
+        <div class="reviews-item__comment <%= "reviews-item__comment--empty" unless review.comment.present? %>"><%= review.comment.presence || "コメントなし" %></div>
+
+        <div class="reviews-item__meta">
+          投稿日: <%= review.created_at.strftime("%Y/%m/%d %H:%M") %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<div class="toilet-reviews-actions">
+  <%= link_to "戻る", search_path, class: "btn btn--secondary btn--sm" %>
+
+  <% if authenticated? %>
+    <% if own_review %>
+      <%= link_to "レビューを編集する", edit_review_path(own_review), class: "btn btn--primary btn--sm" %>
+    <% else %>
+      <%= link_to "レビューを書く", new_toilet_review_path(@toilet), class: "btn btn--primary btn--sm" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/toilet_reviews/new.html.erb
+++ b/app/views/toilet_reviews/new.html.erb
@@ -1,0 +1,48 @@
+<h1 class="page-title">レビューを投稿</h1>
+
+<div class="review-form-card">
+  <div class="review-form-card__toilet">
+    <div class="review-form-card__title"><%= @toilet.name %></div>
+
+    <% if @toilet.station %>
+      <div class="review-form-card__sub">
+        <%= @toilet.station.operator_name %> / <%= @toilet.station.name %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= form_with model: @review, url: toilet_reviews_path(@toilet), local: true do |f| %>
+    <% if @review.errors.any? %>
+      <div class="form-errors">
+        <p class="form-errors__title">入力内容を確認してください</p>
+        <ul class="form-errors__list">
+          <% @review.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="form-group">
+      <%= f.label :rating, "評価", class: "form-label" %>
+      <div class="form-help">1が低め、5が高評価です。</div>
+      <%= f.select :rating,
+          options_for_select(1..5, @review.rating), 
+          { include_blank: "選択してください" },
+          class: "form-select" %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :comment, class: "form-label" do %>
+        コメント <span class="form-label__optional">任意</span>
+      <% end %>
+      <div class="form-help">利用して気づいたことや、場所の分かりやすさなどを書けます。</div>
+      <%= f.text_area :comment, class: "form-textarea", rows: 5, placeholder: "例: 改札内の端の方にありました。比較的見つけやすかったです。" %>
+    </div>
+
+    <div class="review-form-actions">
+      <%= link_to "戻る", toilet_reviews_path(@toilet), class: "btn btn--secondary" %>
+      <%= f.submit "レビューを投稿する", class: "btn btn--primary" %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :toilets, only: [ :index, :show ] do
-    resource :favorite, only: %i[create destroy]
+    resource :favorite, only: [ :create, :destroy ], controller: "toilet_favorites"
+    resources :reviews, only: [ :create ], controller: "toilet_reviews"
   end
 
   resources :favorites, only: [ :index ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   resources :toilets, only: [ :index, :show ] do
     resource :favorite, only: [ :create, :destroy ], controller: "toilet_favorites"
-    resources :reviews, only: [ :create ], controller: "toilet_reviews"
+    resources :reviews, only: [ :index, :new, :create ], controller: "toilet_reviews"
   end
 
   resources :favorites, only: [ :index ]
-  resources :reviews, only: [ :index ]
+  resources :reviews, only: [ :index, :edit, :update, :destroy ]
 
   get "email_confirmations/show"
   get "users/new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   end
 
   resources :favorites, only: [ :index ]
-
+  resources :reviews, only: [ :index ]
 
   get "email_confirmations/show"
   get "users/new"
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
 
   get "/search", to: "search#new"
 
-  # サインアップ（追加）
   get  "/signup", to: "users#new"
   post "/signup", to: "users#create"
 
@@ -28,4 +27,6 @@ Rails.application.routes.draw do
 
   # メールアドレス確認（追加）
   get "/email/confirm", to: "email_confirmations#show", as: :email_confirmation
+
+  get "/mypage", to: "mypages#show", as: :mypage
 end

--- a/db/migrate/20260308040341_create_reviews.rb
+++ b/db/migrate/20260308040341_create_reviews.rb
@@ -1,0 +1,14 @@
+class CreateReviews < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reviews do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :toilet, null: false, foreign_key: true
+      t.integer :rating, null: false
+      t.text :comment
+
+      t.timestamps
+    end
+
+    add_index :reviews, [ :user_id, :toilet_id ], unique: true
+  end
+end

--- a/db/migrate/20260313050108_add_display_name_to_users.rb
+++ b/db/migrate/20260313050108_add_display_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_13_072326) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_08_040341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_13_072326) do
     t.index ["toilet_id"], name: "index_favorites_on_toilet_id"
     t.index ["user_id", "toilet_id"], name: "index_favorites_on_user_id_and_toilet_id", unique: true
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "toilet_id", null: false
+    t.integer "rating", null: false
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["toilet_id"], name: "index_reviews_on_toilet_id"
+    t.index ["user_id", "toilet_id"], name: "index_reviews_on_user_id_and_toilet_id", unique: true
+    t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -74,6 +86,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_13_072326) do
 
   add_foreign_key "favorites", "toilets"
   add_foreign_key "favorites", "users"
+  add_foreign_key "reviews", "toilets"
+  add_foreign_key "reviews", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "toilets", "stations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_08_040341) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_13_050108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_08_040341) do
     t.datetime "updated_at", null: false
     t.string "email_confirmation_token"
     t.datetime "email_confirmed_at"
+    t.string "display_name"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Review, type: :model do
+  let!(:user) do
+    User.create!(
+      email_address: "test+#{SecureRandom.hex(4)}@example.com",
+      password: "password"
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet A",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  it "is valid with rating only" do
+    review = Review.new(user: user, toilet: toilet, rating: 4, comment: "")
+    expect(review).to be_valid
+  end
+
+  it "is invalid without rating" do
+    review = Review.new(user: user, toilet: toilet, rating: nil, comment: "good")
+    expect(review).not_to be_valid
+    expect(review.errors[:rating]).to be_present
+  end
+
+  it "is invalid when rating is outside 1..5" do
+    review = Review.new(user: user, toilet: toilet, rating: 6, comment: "good")
+    expect(review).not_to be_valid
+    expect(review.errors[:rating]).to be_present
+  end
+
+  it "is invalid when the same user reviews the same toilet twice" do
+    Review.create!(user: user, toilet: toilet, rating: 5, comment: "great")
+
+    duplicate_review = Review.new(user: user, toilet: toilet, rating: 4, comment: "good")
+    expect(duplicate_review).not_to be_valid
+    expect(duplicate_review.errors[:user_id]).to be_present
+  end
+
+  it "is invalid when comment is too long" do
+    review = Review.new(user: user, toilet: toilet, rating: 3, comment: "a" * 501)
+    expect(review).not_to be_valid
+    expect(review.errors[:comment]).to be_present
+  end
+end

--- a/spec/requests/reviews_destroy_spec.rb
+++ b/spec/requests/reviews_destroy_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Reviews destroy", type: :request do
+  include AuthHelpers
+
+  let!(:user1) do
+    User.create!(
+      email_address: "u1+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:user2) do
+    User.create!(
+      email_address: "u2+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet A",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  let!(:review1) do
+    Review.create!(
+      user: user1,
+      toilet: toilet,
+      rating: 5,
+      comment: "とても良い"
+    )
+  end
+
+  describe "DELETE /reviews/:id" do
+    context "when owner deletes review" do
+      it "removes the review" do
+        sign_in_as(user1)
+
+        expect {
+          delete "/reviews/#{review1.id}",
+                 headers: auth_headers("ACCEPT" => "text/html")
+        }.to change { Review.count }.by(-1)
+
+        expect(response).to redirect_to(reviews_path)
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "when another user tries to delete" do
+      it "does not delete review" do
+        sign_in_as(user2)
+
+        expect {
+          delete "/reviews/#{review1.id}",
+                 headers: auth_headers("ACCEPT" => "text/html")
+        }.not_to change { Review.count }
+
+        expect([ 302, 403, 404 ]).to include(response.status)
+      end
+    end
+  end
+end

--- a/spec/requests/reviews_edit_spec.rb
+++ b/spec/requests/reviews_edit_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Reviews edit", type: :request do
+  include AuthHelpers
+
+  let!(:user1) do
+    User.create!(
+      email_address: "u1+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:user2) do
+    User.create!(
+      email_address: "u2+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet A",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  let!(:review1) do
+    Review.create!(user: user1, toilet: toilet, rating: 5, comment: "とても良い")
+  end
+
+  describe "GET /reviews/:id/edit" do
+    context "when logged in as review owner" do
+      it "renders the edit page" do
+        sign_in_as(user1)
+
+        get "/reviews/#{review1.id}/edit", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("レビューを編集")
+        expect(response.body).to include("Toilet A")
+        expect(response.body).to include("評価")
+        expect(response.body).to include("コメント")
+        expect(response.body).to include("レビューを更新する")
+      end
+    end
+
+    context "when logged in as another user" do
+      it "does not allow access" do
+        sign_in_as(user2)
+
+        get "/reviews/#{review1.id}/edit", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect([ 302, 404 ]).to include(response.status)
+      end
+    end
+  end
+
+  describe "PATCH /reviews/:id" do
+    context "when logged in as review owner" do
+      it "updates the review" do
+        sign_in_as(user1)
+
+        patch "/reviews/#{review1.id}",
+              params: { review: { rating: 3, comment: "修正後コメント" } },
+              headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to redirect_to(reviews_path)
+
+        review1.reload
+        expect(review1.rating).to eq(3)
+        expect(review1.comment).to eq("修正後コメント")
+      end
+    end
+
+    context "when logged in as another user" do
+      it "does not update the review" do
+        sign_in_as(user2)
+
+        patch "/reviews/#{review1.id}",
+              params: { review: { rating: 1, comment: "勝手に変更" } },
+              headers: auth_headers("ACCEPT" => "text/html")
+
+        expect([ 302, 404 ]).to include(response.status)
+
+        review1.reload
+        expect(review1.rating).to eq(5)
+        expect(review1.comment).to eq("とても良い")
+      end
+    end
+  end
+end

--- a/spec/requests/reviews_index_spec.rb
+++ b/spec/requests/reviews_index_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Reviews index", type: :request do
+  include AuthHelpers
+
+  let!(:user1) do
+    User.create!(
+      email_address: "u1+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:user2) do
+    User.create!(
+      email_address: "u2+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet1) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet 1",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  let!(:toilet2) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet 2",
+      latitude: 35.1,
+      longitude: 139.1
+    )
+  end
+
+  let!(:review1) do
+    Review.create!(user: user1, toilet: toilet1, rating: 5, comment: "とても良い")
+  end
+
+  let!(:review2) do
+    Review.create!(user: user2, toilet: toilet2, rating: 3, comment: "普通")
+  end
+
+  describe "GET /reviews" do
+    context "when logged in" do
+      it "shows only current user's reviews" do
+        sign_in_as(user1)
+
+        get "/reviews", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Toilet 1")
+        expect(response.body).to include("とても良い")
+        expect(response.body).not_to include("Toilet 2")
+        expect(response.body).not_to include("普通")
+      end
+    end
+
+    context "when not logged in" do
+      it "redirects to login or returns 401" do
+        get "/reviews", headers: { "ACCEPT" => "text/html" }
+        expect([ 302, 401 ]).to include(response.status)
+      end
+    end
+  end
+end

--- a/spec/requests/toilet_reviews_index_spec.rb
+++ b/spec/requests/toilet_reviews_index_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Toilet reviews index", type: :request do
+  include AuthHelpers
+
+  let!(:user1) do
+    User.create!(
+      email_address: "u1+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password"),
+      display_name: "Alice"
+    )
+  end
+
+  let!(:user2) do
+    User.create!(
+      email_address: "u2+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password"),
+      display_name: "Bob"
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet1) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet 1",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  let!(:toilet2) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet 2",
+      latitude: 35.1,
+      longitude: 139.1
+    )
+  end
+
+  let!(:review1) do
+    Review.create!(user: user1, toilet: toilet1, rating: 5, comment: "とても良い")
+  end
+
+  let!(:review2) do
+    Review.create!(user: user2, toilet: toilet1, rating: 3, comment: "普通")
+  end
+
+  let!(:review3) do
+    Review.create!(user: user2, toilet: toilet2, rating: 4, comment: "別のトイレ")
+  end
+
+  describe "GET /toilets/:toilet_id/reviews" do
+    it "shows only reviews for the selected toilet" do
+      get "/toilets/#{toilet1.id}/reviews", headers: { "ACCEPT" => "text/html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Toilet 1")
+      expect(response.body).to include("Alice")
+      expect(response.body).to include("Bob")
+      expect(response.body).to include("とても良い")
+      expect(response.body).to include("普通")
+
+      expect(response.body).not_to include("Toilet 2")
+      expect(response.body).not_to include("別のトイレ")
+    end
+
+    it "shows average rating and review count for the selected toilet" do
+      get "/toilets/#{toilet1.id}/reviews", headers: { "ACCEPT" => "text/html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("平均評価")
+      expect(response.body).to include("4.0 / 5")
+      expect(response.body).to include("レビュー 2件")
+    end
+
+    it "shows no reviews message when the toilet has no reviews" do
+      empty_toilet = Toilet.create!(
+        station: station,
+        name: "Empty Toilet",
+        latitude: 35.2,
+        longitude: 139.2
+      )
+
+      get "/toilets/#{empty_toilet.id}/reviews", headers: { "ACCEPT" => "text/html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Empty Toilet")
+      expect(response.body).to include("平均評価 未評価")
+      expect(response.body).to include("レビュー 0件")
+      expect(response.body).to include("このトイレにはまだレビューがありません")
+    end
+  end
+end

--- a/spec/requests/toilet_reviews_new_spec.rb
+++ b/spec/requests/toilet_reviews_new_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe "Toilet reviews new", type: :request do
+  include AuthHelpers
+
+  let!(:user) do
+    User.create!(
+      email_address: "test+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet A",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  describe "GET /toilets/:toilet_id/reviews/new" do
+    context "when logged in" do
+      it "renders the new page" do
+        sign_in_as(user)
+
+        get "/toilets/#{toilet.id}/reviews/new", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("レビューを投稿")
+        expect(response.body).to include("Toilet A")
+      end
+
+      it "shows form help text" do
+        sign_in_as(user)
+
+        get "/toilets/#{toilet.id}/reviews/new", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("1が低め、5が高評価です。")
+        expect(response.body).to include("コメント")
+      end
+    end
+
+    context "when not logged in" do
+      it "redirects to login or returns 401" do
+        get "/toilets/#{toilet.id}/reviews/new", headers: { "ACCEPT" => "text/html" }
+
+        expect([ 302, 401 ]).to include(response.status)
+      end
+    end
+  end
+
+  describe "POST /toilets/:toilet_id/reviews" do
+    context "when logged in" do
+      it "creates a review and redirects to reviews index" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 4, comment: "使いやすい" } },
+               headers: auth_headers("ACCEPT" => "text/html")
+        }.to change { Review.count }.by(1)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(reviews_path)
+      end
+
+      it "creates a review with blank comment" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 4, comment: "" } },
+               headers: auth_headers("ACCEPT" => "text/html")
+        }.to change { Review.count }.by(1)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(reviews_path)
+      end
+
+      it "re-renders the form when rating is invalid" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 6, comment: "bad input" } },
+               headers: auth_headers("ACCEPT" => "text/html")
+        }.not_to change { Review.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("入力内容を確認してください")
+        expect(response.body).to include("Toilet A")
+      end
+    end
+  end
+end

--- a/spec/requests/toilet_reviews_spec.rb
+++ b/spec/requests/toilet_reviews_spec.rb
@@ -40,9 +40,30 @@ RSpec.describe "Toilet reviews", type: :request do
         }.to change { Review.count }.by(1)
 
         expect(response).to have_http_status(:created)
+
         json = JSON.parse(response.body)
         expect(json["rating"]).to eq(4)
         expect(json["comment"]).to eq("")
+
+        created_review = Review.order(:created_at).last
+        expect(created_review.toilet_id).to eq(toilet.id)
+        expect(created_review.user_id).to eq(user.id)
+      end
+
+      it "creates a review with comment" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 5, comment: "とても使いやすい" } },
+               headers: auth_headers("ACCEPT" => "application/json")
+        }.to change { Review.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+
+        json = JSON.parse(response.body)
+        expect(json["rating"]).to eq(5)
+        expect(json["comment"]).to eq("とても使いやすい")
       end
     end
 
@@ -57,7 +78,7 @@ RSpec.describe "Toilet reviews", type: :request do
     end
 
     context "when rating is invalid" do
-      it "returns 422" do
+      it "returns 422 and does not create a review" do
         sign_in_as(user)
 
         expect {
@@ -66,12 +87,15 @@ RSpec.describe "Toilet reviews", type: :request do
                headers: auth_headers("ACCEPT" => "application/json")
         }.not_to change { Review.count }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
+
+        json = JSON.parse(response.body)
+        expect(json).to be_a(Hash)
       end
     end
 
     context "when the same user already reviewed the toilet" do
-      it "returns 422" do
+      it "returns 422 and does not create another review" do
         sign_in_as(user)
         Review.create!(user: user, toilet: toilet, rating: 5, comment: "great")
 
@@ -81,7 +105,10 @@ RSpec.describe "Toilet reviews", type: :request do
                headers: auth_headers("ACCEPT" => "application/json")
         }.not_to change { Review.count }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
+
+        json = JSON.parse(response.body)
+        expect(json).to be_a(Hash)
       end
     end
   end

--- a/spec/requests/toilet_reviews_spec.rb
+++ b/spec/requests/toilet_reviews_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "Toilet reviews", type: :request do
+  include AuthHelpers
+
+  let!(:user) do
+    User.create!(
+      email_address: "test+#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet) do
+    Toilet.create!(
+      station: station,
+      name: "Toilet A",
+      latitude: 35.0,
+      longitude: 139.0
+    )
+  end
+
+  describe "POST /toilets/:toilet_id/reviews" do
+    context "when logged in" do
+      it "creates a review with rating only" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 4, comment: "" } },
+               headers: auth_headers("ACCEPT" => "application/json")
+        }.to change { Review.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json["rating"]).to eq(4)
+        expect(json["comment"]).to eq("")
+      end
+    end
+
+    context "when not logged in" do
+      it "returns 401" do
+        post "/toilets/#{toilet.id}/reviews",
+             params: { review: { rating: 4, comment: "good" } },
+             headers: { "ACCEPT" => "application/json" }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when rating is invalid" do
+      it "returns 422" do
+        sign_in_as(user)
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 6, comment: "bad input" } },
+               headers: auth_headers("ACCEPT" => "application/json")
+        }.not_to change { Review.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when the same user already reviewed the toilet" do
+      it "returns 422" do
+        sign_in_as(user)
+        Review.create!(user: user, toilet: toilet, rating: 5, comment: "great")
+
+        expect {
+          post "/toilets/#{toilet.id}/reviews",
+               params: { review: { rating: 4, comment: "again" } },
+               headers: auth_headers("ACCEPT" => "application/json")
+        }.not_to change { Review.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/requests/toilets_json_spec.rb
+++ b/spec/requests/toilets_json_spec.rb
@@ -56,5 +56,29 @@ RSpec.describe "Toilets JSON", type: :request do
       get "/favorites", headers: auth_headers
       expect(response.body).to include(toilet.name)
     end
+
+    it "includes reviews and review summary in show json" do
+      Review.create!(user: user, toilet: toilet, rating: 5, comment: "とても使いやすい")
+      Review.create!(
+        user: User.create!(
+          email_address: "another+#{SecureRandom.hex(4)}@example.com",
+          password: "password"
+        ),
+        toilet: toilet,
+        rating: 3,
+        comment: ""
+      )
+
+      get "/toilets/#{toilet.id}.json", headers: { "ACCEPT" => "application/json" }
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      expect(json["review_summary"]["review_count"]).to eq(2)
+      expect(json["review_summary"]["average_rating"]).to eq(4.0)
+
+      expect(json["reviews"].size).to eq(2)
+      expect(json["reviews"].first).to include("rating", "comment", "created_at", "user")
+    end
   end
 end


### PR DESCRIPTION
## 概要
レビュー機能まわりのUI/UX改善と導線整理を行いました。
トイレ別レビュー一覧、評価・投稿一覧、トイレ詳細モーダル、レビュー投稿/編集フォームの表示を見直し、レビューの閲覧・投稿・編集がしやすい状態に整えました。
あわせて、関連する request spec を追加・修正し、レビュー機能の表示・投稿・編集・削除の挙動を確認できるようにしました。

### 関連issue 
Close #67, #68

## 変更内容
- トイレ別レビュー一覧画面のUI改善
- 平均評価表示、レビュー件数表示を追加
- レビュー0件時の空状態UIを追加
- コメント表示領域の見た目を調整
- 評価・投稿一覧画面のUI改善
- 自分のレビュー一覧の見た目を調整
- 「トイレを表示する」ボタンから該当トイレの詳細モーダルを開けるように変更
- トイレ詳細モーダルのレビュー表示改善
- 最新レビューの表示レイアウトを調整
- 長文コメントはモーダル内で省略表示するよう変更
- レビュー投稿 / 編集フォームのUI改善
- 補助文、任意表示、placeholder を追加
- ボタンサイズ・見た目を統一
- エラー表示を見やすく調整
- ヘッダーメニューのログアウト項目の見た目を他メニューと統一
- geolocation.js の整理
- モーダル起動処理を共通化
- favorites 用処理とモーダル表示処理の責務を整理
- review 関連 request spec の追加・修正
- toilet_reviews 系 spec の強化
- reviews index / edit / destroy 系 spec の整理・追加
- spec / rubocop が通るよう調整

## 確認方法
docker compose exec web bundle exec rspec を実行し、テストが通ることを確認する
docker compose exec web bundle exec rubocop を実行し、Lint エラーがないことを確認する
ローカルで以下を確認する
トイレ別レビュー一覧画面で平均評価・件数・0件表示が正しく出ること
評価・投稿一覧画面で自分のレビューのみ表示されること
評価・投稿一覧画面の「トイレを表示する」押下で該当トイレの詳細モーダルが開くこと
レビュー投稿 / 編集フォームの見た目とエラー表示が崩れていないこと
ヘッダーメニューのログアウト項目が他項目と揃っていること

## スクリーンショット
![トイレ別レビュー一覧画面](https://i.gyazo.com/a13cdfc93a6cc7fb0c35201182cc1202.png)
![評価・投稿一覧画面](https://i.gyazo.com/afcb2d0173394e7054de6f2dac4c07b6.png)
![トイレ詳細モーダルのレビュー表示](https://i.gyazo.com/6424e161c84232a64923192891d01adc.png)
![レビュー投稿画面](https://i.gyazo.com/f16988bc248aaa1c5be371df9253a6f1.png)
![レビュー編集画面](https://i.gyazo.com/d50a962e143e91166dc361af02552cb8.png)

## セルフレビューチェックリスト
- [x] 不要なコードやコメントアウトが残っていないか
- [x] コンソールログやデバッグコードが残っていないか
- [x] N+1クエリが発生していないか
- [x] エラーハンドリングは適切か
- [x] バリデーションは適切に設定されているか
- [x] テストは書いたか（必要に応じて）
- [x] コーディング規約に従っているか
- [x] 実装漏れがないか