### PR TITLE
Feature/search filters

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -315,6 +315,19 @@
   background: #fff;
 }
 
+.search-filters__count {
+  margin-left: 6px;
+  font-size: 12px;
+  color: #666;
+  font-weight: 400;
+}
+
+.search-filters__actions {
+  margin-top: 4px;
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* --- トイレ一覧 --- */
 #toilet-list {
   margin-top: 12px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -268,6 +268,53 @@
   border-radius: 10px;
 }
 
+.search-filters {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.search-filters__summary {
+  padding: 10px 12px;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.search-filters__summary::-webkit-details-marker {
+  display: none;
+}
+
+.search-filters__body {
+  padding: 0 12px 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.search-filters__option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.search-filters__option--stack {
+  display: grid;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.search-filters__select {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 14px;
+  background: #fff;
+}
+
 /* --- トイレ一覧 --- */
 #toilet-list {
   margin-top: 12px;

--- a/app/controllers/toilets_controller.rb
+++ b/app/controllers/toilets_controller.rb
@@ -5,6 +5,8 @@ class ToiletsController < ApplicationController
 
   def index
     toilets = Toilet.includes(:station).order(:id)
+    toilets = filter_toilets(toilets)
+
     render json: build_payload(toilets), status: :ok
   end
 
@@ -15,6 +17,20 @@ class ToiletsController < ApplicationController
   end
 
   private
+
+  def filter_toilets(toilets)
+    toilets = toilets.where(is_multipurpose: true) if truthy_param?(params[:multipurpose])
+    toilets = toilets.where(is_wheelchair_accessible: true) if truthy_param?(params[:wheelchair_accessible])
+    toilets = toilets.where(is_baby_friendly: true) if truthy_param?(params[:baby_friendly])
+    toilets = toilets.where(is_ostomate_accessible: true) if truthy_param?(params[:ostomate_accessible])
+    toilets = toilets.where(has_washlet: true) if truthy_param?(params[:washlet])
+    toilets = toilets.where(style_type: params[:style_type]) if params[:style_type].present?
+    toilets
+  end
+
+  def truthy_param?(value)
+    value == "1" || value == "true"
+  end
 
   def build_payload(toilets)
     favorited_ids =

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -37,6 +37,59 @@ function buildFacilityIconsHtml(toilet) {
     .join("");
 }
 
+function buildToiletFilterParams() {
+  const params = new URLSearchParams();
+
+  const multipurpose = document.getElementById("filter-multipurpose");
+  const wheelchairAccessible = document.getElementById("filter-wheelchair-accessible");
+  const babyFriendly = document.getElementById("filter-baby-friendly");
+  const ostomateAccessible = document.getElementById("filter-ostomate-accessible");
+  const washlet = document.getElementById("filter-washlet");
+  const styleType = document.getElementById("filter-style-type");
+
+  if (multipurpose?.checked) {
+    params.set("multipurpose", "1");
+  }
+
+  if (wheelchairAccessible?.checked) {
+    params.set("wheelchair_accessible", "1");
+  }
+
+  if (babyFriendly?.checked) {
+    params.set("baby_friendly", "1");
+  }
+
+  if (ostomateAccessible?.checked) {
+    params.set("ostomate_accessible", "1");
+  }
+
+  if (washlet?.checked) {
+    params.set("washlet", "1");
+  }
+
+  if (styleType?.value) {
+    params.set("style_type", styleType.value);
+  }
+
+  return params;
+}
+
+function getDistanceFilterValue() {
+  const distanceFilter = document.getElementById("filter-distance");
+  if (!distanceFilter) return null;
+
+  const value = distanceFilter.value;
+  if (!value) return null;
+
+  return Number(value);
+}
+
+function filterToiletsByDistance(toilets) {
+  const maxDistance = getDistanceFilterValue();
+  if (!Number.isFinite(maxDistance)) return toilets;
+
+  return toilets.filter((toilet) => toilet.distance_in_meters <= maxDistance);
+}
 
 async function setupGeolocationButton() {
   const button = document.getElementById("get-location");
@@ -45,47 +98,21 @@ async function setupGeolocationButton() {
 
   if (!button || !result || !mapElement) return;
 
-  // ✅ Turbo再訪で多重登録されないように
   if (button.dataset.geolocationBound === "true") return;
   button.dataset.geolocationBound = "true";
 
   const apiKey = mapElement.dataset.mapApiKeyValue;
 
   async function fetchToilets() {
-    const res = await fetch("/toilets.json", { credentials: "same-origin" });
+    const params = buildToiletFilterParams();
+    const url = params.toString().length > 0 ? `/toilets.json?${params.toString()}` : "/toilets.json";
+
+    const res = await fetch(url, { credentials: "same-origin" });
     if (!res.ok) throw new Error(`Failed to fetch toilets: ${res.status}`);
     return await res.json();
   }
 
-  let toilets = [];
-  try {
-    toilets = await fetchToilets();
-  } catch (e) {
-    toilets = [];
-    clearToiletList();
-    showErrorStatus("データの読み込みに失敗しました。ページを再読み込みしてください。");
-  }
-
-  const modalClose = document.getElementById("toilet-modal-close");
-  const modalBackdrop = document.getElementById("toilet-modal-backdrop");
-
-  if (modalClose && modalClose.dataset.bound !== "true") {
-    modalClose.dataset.bound = "true";
-    modalClose.addEventListener("click", closeToiletModal);
-  }
-  if (modalBackdrop && modalBackdrop.dataset.bound !== "true") {
-    modalBackdrop.dataset.bound = "true";
-    modalBackdrop.addEventListener("click", closeToiletModal);
-  }
-
-  if (document.documentElement.dataset.toiletModalEscBound !== "true") {
-    document.documentElement.dataset.toiletModalEscBound = "true";
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") closeToiletModal();
-    });
-  }
-
-  function startGeolocation() {
+  async function startGeolocation() {
     result.textContent = "";
     hideStatus();
 
@@ -97,7 +124,7 @@ async function setupGeolocationButton() {
     showLoadingStatus("現在地を取得しています...");
 
     navigator.geolocation.getCurrentPosition(
-      (position) => {
+      async (position) => {
         const lat = position.coords.latitude;
         const lng = position.coords.longitude;
         const accuracy = position.coords.accuracy;
@@ -105,8 +132,32 @@ async function setupGeolocationButton() {
         result.textContent =
           `lat=${lat.toFixed(6)}, lng=${lng.toFixed(6)}（精度: 約${Math.round(accuracy)}m）`;
 
-        
-        loadGoogleMap(apiKey, lat, lng, toilets);
+        try {
+          const toilets = await fetchToilets();
+
+          const sortedToilets = toilets
+            .map((toilet) => {
+              const distanceInMeters = calculateDistanceInMeters(
+                lat,
+                lng,
+                Number(toilet.latitude),
+                Number(toilet.longitude)
+              );
+
+              return {
+                ...toilet,
+                distance_in_meters: distanceInMeters
+              };
+            })
+            .sort((a, b) => a.distance_in_meters - b.distance_in_meters);
+
+          const visibleToilets = filterToiletsByDistance(sortedToilets);
+
+          loadGoogleMap(apiKey, lat, lng, visibleToilets);
+        } catch (e) {
+          clearToiletList();
+          showErrorStatus("データの読み込みに失敗しました。ページを再読み込みしてください。");
+        }
       },
       (error) => {
         hideStatus();
@@ -121,10 +172,33 @@ async function setupGeolocationButton() {
     );
   }
 
+  function bindSearchFilters() {
+    const filterIds = [
+      "filter-distance",
+      "filter-style-type",
+      "filter-multipurpose",
+      "filter-wheelchair-accessible",
+      "filter-baby-friendly",
+      "filter-ostomate-accessible",
+      "filter-washlet"
+    ];
+
+    filterIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (!el || el.dataset.bound === "true") return;
+
+      el.dataset.bound = "true";
+      el.addEventListener("change", () => {
+        startGeolocation();
+      });
+    });
+  }
+
   button.addEventListener("click", () => {
     startGeolocation();
   });
 
+  bindSearchFilters();
   startGeolocation();
 }
 
@@ -292,6 +366,35 @@ function escapeHtml(str) {
     const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
     return map[s];
   });
+}
+
+function calculateDistanceInMeters(lat1, lng1, lat2, lng2) {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const earthRadius = 6371000;
+
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return Math.round(earthRadius * c);
+}
+
+function formatDistance(distanceInMeters) {
+  if (!Number.isFinite(distanceInMeters)) return "";
+
+  if (distanceInMeters < 1000) {
+    return `約${distanceInMeters}m`;
+  }
+
+  return `約${(distanceInMeters / 1000).toFixed(1)}km`;
 }
 
 function truncateText(text, maxLength = 48) {

--- a/app/javascript/geolocation.js
+++ b/app/javascript/geolocation.js
@@ -74,6 +74,64 @@ function buildToiletFilterParams() {
   return params;
 }
 
+function countActiveFilters() {
+  let count = 0;
+
+  const distanceFilter = document.getElementById("filter-distance");
+  const styleTypeFilter = document.getElementById("filter-style-type");
+  const multipurpose = document.getElementById("filter-multipurpose");
+  const wheelchairAccessible = document.getElementById("filter-wheelchair-accessible");
+  const babyFriendly = document.getElementById("filter-baby-friendly");
+  const ostomateAccessible = document.getElementById("filter-ostomate-accessible");
+  const washlet = document.getElementById("filter-washlet");
+
+  if (distanceFilter?.value) count += 1;
+  if (styleTypeFilter?.value) count += 1;
+  if (multipurpose?.checked) count += 1;
+  if (wheelchairAccessible?.checked) count += 1;
+  if (babyFriendly?.checked) count += 1;
+  if (ostomateAccessible?.checked) count += 1;
+  if (washlet?.checked) count += 1;
+
+  return count;
+}
+
+function updateActiveFilterCount() {
+  const countEl = document.getElementById("active-filter-count");
+  if (!countEl) return;
+
+  const count = countActiveFilters();
+
+  if (count === 0) {
+    countEl.hidden = true;
+    countEl.textContent = "";
+    return;
+  }
+
+  countEl.hidden = false;
+  countEl.textContent = `（${count}件適用中）`;
+}
+
+function clearSearchFilters() {
+  const distanceFilter = document.getElementById("filter-distance");
+  const styleTypeFilter = document.getElementById("filter-style-type");
+  const multipurpose = document.getElementById("filter-multipurpose");
+  const wheelchairAccessible = document.getElementById("filter-wheelchair-accessible");
+  const babyFriendly = document.getElementById("filter-baby-friendly");
+  const ostomateAccessible = document.getElementById("filter-ostomate-accessible");
+  const washlet = document.getElementById("filter-washlet");
+
+  if (distanceFilter) distanceFilter.value = "";
+  if (styleTypeFilter) styleTypeFilter.value = "";
+  if (multipurpose) multipurpose.checked = false;
+  if (wheelchairAccessible) wheelchairAccessible.checked = false;
+  if (babyFriendly) babyFriendly.checked = false;
+  if (ostomateAccessible) ostomateAccessible.checked = false;
+  if (washlet) washlet.checked = false;
+
+  updateActiveFilterCount();
+}
+
 function getDistanceFilterValue() {
   const distanceFilter = document.getElementById("filter-distance");
   if (!distanceFilter) return null;
@@ -189,8 +247,20 @@ async function setupGeolocationButton() {
 
       el.dataset.bound = "true";
       el.addEventListener("change", () => {
+        updateActiveFilterCount();
         startGeolocation();
       });
+    });
+  }
+
+  function bindClearFiltersButton() {
+    const clearButton = document.getElementById("clear-search-filters");
+    if (!clearButton || clearButton.dataset.bound === "true") return;
+
+    clearButton.dataset.bound = "true";
+    clearButton.addEventListener("click", () => {
+      clearSearchFilters();
+      startGeolocation();
     });
   }
 
@@ -199,6 +269,8 @@ async function setupGeolocationButton() {
   });
 
   bindSearchFilters();
+  bindClearFiltersButton();
+  updateActiveFilterCount();
   startGeolocation();
 }
 

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,6 +1,57 @@
 <div class="search-toolbar">
   <p id="location-result" hidden></p>
+
+  <details class="search-filters">
+    <summary class="search-filters__summary">設備条件で絞り込む</summary>
+
+    <div class="search-filters__body">
+      <label class="search-filters__option search-filters__option--stack">
+        <span>距離条件</span>
+        <select id="filter-distance" class="search-filters__select">
+          <option value="">制限なし</option>
+          <option value="500">500m以内</option>
+          <option value="1000">1000m以内</option>
+        </select>
+      </label>
+
+      <label class="search-filters__option search-filters__option--stack">
+        <span>便器タイプ</span>
+        <select id="filter-style-type" class="search-filters__select">
+          <option value="">指定なし</option>
+          <option value="japanese">和式</option>
+          <option value="western">洋式</option>
+          <option value="both">併設</option>
+        </select>
+      </label>
+
+      <label class="search-filters__option">
+        <input type="checkbox" id="filter-ostomate-accessible">
+        オストメイト対応
+      </label>
+
+      <label class="search-filters__option">
+        <input type="checkbox" id="filter-washlet">
+        ウォシュレット
+      </label>
+
+      <label class="search-filters__option">
+        <input type="checkbox" id="filter-multipurpose">
+        多目的トイレ
+      </label>
+
+      <label class="search-filters__option">
+        <input type="checkbox" id="filter-wheelchair-accessible">
+        車いす対応
+      </label>
+
+      <label class="search-filters__option">
+        <input type="checkbox" id="filter-baby-friendly">
+        ベビー対応
+      </label>
+    </div>
+  </details>
 </div>
+
 <div
   id="map"
   data-is-logged-in-value="false"

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -2,7 +2,10 @@
   <p id="location-result" hidden></p>
 
   <details class="search-filters">
-    <summary class="search-filters__summary">設備条件で絞り込む</summary>
+    <summary class="search-filters__summary">
+      設備条件で絞り込む
+      <span id="active-filter-count" class="search-filters__count" hidden></span>
+    </summary>
 
     <div class="search-filters__body">
       <label class="search-filters__option search-filters__option--stack">
@@ -48,6 +51,12 @@
         <input type="checkbox" id="filter-baby-friendly">
         ベビー対応
       </label>
+  
+      <div class="search-filters__actions">
+        <button type="button" id="clear-search-filters" class="btn btn--secondary btn--sm">
+          条件をクリア
+        </button>
+      </div>
     </div>
   </details>
 </div>

--- a/spec/requests/toilets_spec.rb
+++ b/spec/requests/toilets_spec.rb
@@ -1,0 +1,259 @@
+require "rails_helper"
+
+RSpec.describe "Toilets", type: :request do
+  let!(:station) do
+    Station.create!(
+      name: "Station A",
+      operator_name: "Operator A",
+      latitude: 35.681236,
+      longitude: 139.767125
+    )
+  end
+
+  let!(:toilet1) do
+    Toilet.create!(
+      station: station,
+      name: "Multipurpose Toilet",
+      latitude: 35.0,
+      longitude: 139.0,
+      style_type: :western,
+      has_washlet: true,
+      is_multipurpose: true,
+      is_wheelchair_accessible: false,
+      is_baby_friendly: false,
+      is_ostomate_accessible: false
+    )
+  end
+
+  let!(:toilet2) do
+    Toilet.create!(
+      station: station,
+      name: "Wheelchair Toilet",
+      latitude: 35.1,
+      longitude: 139.1,
+      style_type: :japanese,
+      has_washlet: false,
+      is_multipurpose: false,
+      is_wheelchair_accessible: true,
+      is_baby_friendly: false,
+      is_ostomate_accessible: true
+    )
+  end
+
+    let!(:toilet3) do
+    Toilet.create!(
+      station: station,
+      name: "Baby Friendly Toilet",
+      latitude: 35.2,
+      longitude: 139.2,
+      style_type: :both,
+      has_washlet: true,
+      is_multipurpose: false,
+      is_wheelchair_accessible: false,
+      is_baby_friendly: true,
+      is_ostomate_accessible: false
+    )
+  end
+
+    let!(:toilet4) do
+    Toilet.create!(
+      station: station,
+      name: "All Conditions Toilet",
+      latitude: 35.3,
+      longitude: 139.3,
+      style_type: :western,
+      has_washlet: true,
+      is_multipurpose: true,
+      is_wheelchair_accessible: true,
+      is_baby_friendly: true,
+      is_ostomate_accessible: true
+    )
+  end
+
+  describe "GET /toilets.json" do
+    it "returns all toilets when no filters are given" do
+      get "/toilets.json", headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include(
+        "Multipurpose Toilet",
+        "Wheelchair Toilet",
+        "Baby Friendly Toilet",
+        "All Conditions Toilet"
+      )
+    end
+
+    it "filters by multipurpose" do
+      get "/toilets.json",
+        params: { multipurpose: "1" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Multipurpose Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Wheelchair Toilet", "Baby Friendly Toilet")
+    end
+
+    it "filters by wheelchair accessibility" do
+      get "/toilets.json",
+        params: { wheelchair_accessible: "1" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Wheelchair Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Baby Friendly Toilet")
+    end
+
+    it "filters by baby friendly" do
+      get "/toilets.json",
+        params: { baby_friendly: "1" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Baby Friendly Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Wheelchair Toilet")
+    end
+
+    it "filters by ostomate accessibility" do
+      get "/toilets.json",
+        params: { ostomate_accessible: "1" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Wheelchair Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Baby Friendly Toilet")
+    end
+
+    it "filters by washlet" do
+      get "/toilets.json",
+        params: { washlet: "1" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Multipurpose Toilet", "Baby Friendly Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Wheelchair Toilet")
+    end
+
+    it "filters by western style" do
+      get "/toilets.json",
+        params: { style_type: "western" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Multipurpose Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Wheelchair Toilet", "Baby Friendly Toilet")
+    end
+
+    it "filters by japanese style" do
+      get "/toilets.json",
+        params: { style_type: "japanese" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Wheelchair Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Baby Friendly Toilet", "All Conditions Toilet")
+    end
+
+    it "filters by both style" do
+      get "/toilets.json",
+        params: { style_type: "both" },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Baby Friendly Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Wheelchair Toilet", "All Conditions Toilet")
+    end
+
+    it "applies style_type and washlet filters with AND condition" do
+      get "/toilets.json",
+        params: {
+          style_type: "western",
+          washlet: "1"
+        },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Multipurpose Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Wheelchair Toilet", "Baby Friendly Toilet")
+    end
+
+    it "applies ostomate and wheelchair filters with AND condition" do
+      get "/toilets.json",
+        params: {
+          ostomate_accessible: "1",
+          wheelchair_accessible: "1"
+        },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("Wheelchair Toilet", "All Conditions Toilet")
+      expect(names).not_to include("Multipurpose Toilet", "Baby Friendly Toilet")
+    end
+
+    it "applies multiple filters with AND condition" do
+      get "/toilets.json",
+        params: {
+          multipurpose: "1",
+          wheelchair_accessible: "1",
+          baby_friendly: "1"
+        },
+        headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      names = json.map { |toilet| toilet["name"] }
+
+      expect(names).to include("All Conditions Toilet")
+
+      json.each do |toilet|
+        expect(toilet["is_multipurpose"]).to eq(true)
+        expect(toilet["is_wheelchair_accessible"]).to eq(true)
+        expect(toilet["is_baby_friendly"]).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
検索機能を拡張し、設備条件や距離条件でトイレ候補を絞り込めるようにしました。
あわせて、現在地から近い順で候補を並べるようにし、検索体験を改善しました。
検索条件に対応する request spec も追加・拡張し、絞り込み条件が正しく動作することを確認できるようにしました。

## 関連issue
Close #73 

## 変更内容
- 検索フィルタUIを追加
- 距離条件（制限なし / 500m以内 / 1000m以内）
  - 多目的トイレ
  - 車いす対応
  - ベビー対応
  - オストメイト対応
  - ウォシュレット
  - 便器タイプ（和式 / 洋式 / 併設）
- 設備条件フィルタを折りたたみ式UIに変更
- 地図表示領域を圧迫しすぎないよう調整
- 折りたたみ矢印の重複表示を整理
- 検索条件の使いやすさを改善
- 適用中の条件数を表示
- 条件をまとめて解除できる「条件をクリア」ボタンを追加
- /toilets.json の検索条件対応を拡張
- 現在地からの距離を内部的に計算し、近い順で候補を並べるよう変更
- 一覧表示と地図表示で同じ候補が出るよう調整
- toilets_spec.rb を拡張
- 設備条件ごとの単体フィルタ
- 複合条件の AND 条件

## 確認方法
docker compose exec web bundle exec rspec を実行し、テストが通ることを確認する
docker compose exec web bundle exec rubocop を実行し、Lint エラーがないことを確認する
ローカルで /search を開き、以下を確認する
設備条件フィルタが折りたたみ形式で表示されること
多目的 / 車いす / ベビー / オストメイト / ウォシュレット / 便器タイプで絞り込めること
距離条件（500m / 1000m）で候補が切り替わること
複数条件を組み合わせたときに AND 条件で絞られること
一覧と地図で表示される候補が一致すること
候補が現在地から近い順に並んでいること
適用中条件数が表示されること
「条件をクリア」で初期状態に戻せること


## スクリーンショット
![](https://i.gyazo.com/a79db24f06c75b2b41df1b30b4b8546a.png)
![](https://i.gyazo.com/ce20427c4fcf7d516dcdb3bba5ad1df0.png)

## セルフレビューチェックリスト
- [x]  使っていないコードや、コメントアウトしたままのコードが残っていない
- [x]  確認用に入れた console.log やデバッグコードが残っていない
- [x]  追加・修正した機能が、実際に画面や操作で正しく動く
- [x]  エラーが出る場合に、画面上で不自然な状態にならない
- [x]  他の機能に影響が出ていない
- [x]  同じような処理やコードが不必要に重複していない
- [x]  変数名やメソッド名が、何をしているか分かる名前になっている
- [x]  テストを書いた、または既存テストを更新した
- [x]  RSpec が通っている
- [x]  Rubocop が通っている
