### PR TITLE
マイページの機能と導線を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1343,3 +1343,22 @@ body.is-modal-open .toilet-modal__backdrop {
   color: #444;
   line-height: 1.7;
 }
+
+.mypage-card {
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.mypage-card__text {
+  margin: 0;
+  color: #444;
+  line-height: 1.7;
+}
+
+.mypage-menu {
+  display: grid;
+  gap: 12px;
+}

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -29,8 +29,11 @@ module Authentication
 
       respond_to do |format|
         format.json { head :unauthorized }
-        format.html { redirect_to new_session_path, alert: "ログインが必要です" }
-        format.any  { head :unauthorized }
+        format.html do
+          request_authentication
+          flash[:alert] = "ログインが必要です"
+        end
+        format.any { head :unauthorized }
       end
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,8 +59,7 @@
             <%= link_to "お気に入り", favorites_path, class: "site-nav__link" %>
             <span class="site-nav__link site-nav__link--disabled">通勤・通学ルート（準備中）</span>
             <%= link_to "評価・投稿一覧", reviews_path, class: "site-nav__link" %>
-            <span class="site-nav__link site-nav__link--disabled">評価・投稿一覧（準備中）</span>
-            <span class="site-nav__link site-nav__link--disabled">マイページ（準備中）</span>
+            <%= link_to "マイページ", mypage_path, class: "site-nav__link" %>
 
             <%= button_to "ログアウト", session_path,
                   method: :delete,
@@ -101,8 +100,7 @@
             <%= link_to "お気に入り", favorites_path, class: "mobile-menu__link" %>
             <span class="mobile-menu__link mobile-menu__link--disabled">通勤・通学ルート（準備中）</span>
             <%= link_to "評価・投稿一覧", reviews_path, class: "mobile-menu__link" %>
-            <span class="mobile-menu__link mobile-menu__link--disabled">評価・投稿一覧（準備中）</span>
-            <span class="mobile-menu__link mobile-menu__link--disabled">マイページ（準備中）</span>
+            <%= link_to "マイページ", mypage_path, class: "mobile-menu__link" %>
 
             <%= button_to "ログアウト", session_path,
                   method: :delete,

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,6 +1,13 @@
 <h1 class="page-title">マイページ</h1>
 
+<div class="mypage-card">
+  <p class="mypage-card__text">
+    お気に入りや自分のレビューを、ここからまとめて確認できます。
+  </p>
+</div>
+
 <div class="mypage-menu">
   <%= link_to "お気に入り一覧", favorites_path, class: "btn btn--primary btn--block" %>
-  <%= link_to "レビュー一覧", reviews_path, class: "btn btn--secondary btn--block" %>
+  <%= link_to "評価・投稿一覧", reviews_path, class: "btn btn--secondary btn--block" %>
+  <%= link_to "トイレを探す", search_path, class: "btn btn--secondary btn--block" %>
 </div>

--- a/spec/requests/mypages_spec.rb
+++ b/spec/requests/mypages_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Mypage", type: :request do
+  include AuthHelpers
+
+  let!(:user) do
+    User.create!(
+      email_address: "mypage-#{SecureRandom.hex(4)}@example.com",
+      password_digest: BCrypt::Password.create("password")
+    )
+  end
+
+  describe "GET /mypage" do
+    context "when logged in" do
+      it "renders the mypage" do
+        sign_in_as(user)
+
+        get "/mypage", headers: auth_headers("ACCEPT" => "text/html")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("マイページ")
+        expect(response.body).to include("お気に入り一覧")
+        expect(response.body).to include("評価・投稿一覧")
+      end
+    end
+
+    context "when not logged in" do
+      it "redirects to login or returns 401" do
+        get "/mypage", headers: { "ACCEPT" => "text/html" }
+
+        expect([ 302, 401 ]).to include(response.status)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
マイページを実装し、ログインユーザーが自分向けの機能へまとまってアクセスできるようにしました。
あわせて、ヘッダーおよびモバイルメニューの導線を整理し、未ログイン時にはログイン画面へ誘導されることを確認しました。

## 変更内容
- マイページ (/mypage) を実装
- マイページに以下の導線を追加
  - お気に入り一覧
  - 評価・投稿一覧
  - トイレを探す
- マイページに説明文を追加し、ページの役割が分かるように調整
 - ヘッダーのログイン時メニューを整理
- マイページ（準備中） を実際の マイページ 導線に変更
- 重複していた準備中表示を整理
- モバイルメニューにも マイページ 導線を追加
- 未ログイン状態で /mypage にアクセスした場合、ログイン画面へ誘導されるよう認証導線を確認・修正
- mypages_spec.rb を追加し、表示とアクセス制御を確認できるようにした

## 確認方法
docker compose exec web bundle exec rspec を実行し、テストが通ることを確認する
docker compose exec web bundle exec rubocop を実行し、Lint エラーがないことを確認する
ログイン状態で以下を確認する
ヘッダーから マイページ に遷移できること
モバイルメニューから マイページ に遷移できること
マイページに お気に入り一覧 評価・投稿一覧 トイレを探す が表示されること
各リンク先へ遷移できること
未ログイン状態で /mypage に直接アクセスし、ログインが必要です の表示とともにログイン画面へ遷移することを確認する

## スクリーンショット
ログイン時のヘッダーメニュー
![](https://i.gyazo.com/ea3ed18152da8af22f61688cbe541d81.png)

マイページ画面
![](https://i.gyazo.com/391bdf939ce70057e9ba50d07d3da680.png)

未ログイン時に /mypage へアクセスした際のログイン画面
![](https://i.gyazo.com/09e61a00f81dbce22319e5f3f4b2bc2a.png)

## セルフレビューチェックリスト
 - [x] 使っていないコードや、コメントアウトしたままのコードが残っていない
- [x]  確認用に入れた console.log やデバッグコードが残っていない
- [x]  追加・修正した機能が、実際に画面や操作で正しく動く
- [x]  エラーが出る場合に、画面上で不自然な状態にならない
- [x]  他の機能に影響が出ていない
- [x]  同じような処理やコードが不必要に重複していない
- [x]  変数名やメソッド名が、何をしているか分かる名前になっている
- [x]  テストを書いた、または既存テストを更新した
- [x]  RSpec が通っている
- [x]  Rubocop が通っている