### PR TITLE
評価投稿に不適切対策を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1379,3 +1379,36 @@ body.is-modal-open .toilet-modal__backdrop {
   border-radius: 10px;
   border: 1px solid #e5e5e5;
 }
+
+.form-note-box {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid #e3e3e3;
+  border-radius: 8px;
+  background-color: #fafafa;
+}
+
+.form-note-box__limit {
+  margin: 0 0 4px;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: #666;
+  font-weight: 600;
+}
+
+.form-note {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: #666;
+}
+
+.form-note + .form-note {
+  margin-top: 2px;
+}
+
+.form-help-text {
+  margin-top: 6px;
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,11 +4,21 @@ class Review < ApplicationRecord
 
   has_one_attached :image
 
+  NG_WORDS = %w[
+    ばか
+    バカ
+    あほ
+    アホ
+    しね
+    死ね
+  ].freeze
+
   validates :rating, presence: true, inclusion: { in: 1..5 }
   validates :comment, length: { maximum: 500 }, allow_blank: true
   validates :user_id, uniqueness: { scope: :toilet_id }
 
   validate :image_must_be_valid
+  validate :comment_must_not_include_ng_words
 
   private
 
@@ -21,6 +31,14 @@ class Review < ApplicationRecord
 
     if image.blob.byte_size > 5.megabytes
       errors.add(:image, "は 5MB 以下にしてください")
+    end
+  end
+
+  def comment_must_not_include_ng_words
+    return if comment.blank?
+
+    if NG_WORDS.any? { |word| comment.include?(word) }
+      errors.add(:comment, "に不適切な表現が含まれています")
     end
   end
 end

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -36,18 +36,25 @@
         コメント <span class="form-label__optional">任意</span>
       <% end %>
       <%= f.text_area :comment,
-          rows: 5,
           class: "form-textarea",
-          placeholder: "使いやすさや気づいたことがあれば入力してください" %>
+          rows: 5,
+          placeholder: "例: 改札内の端の方にありました。比較的見つけやすかったです。" %>
     </div>
 
     <div class="form-group">
       <%= f.label :image, class: "form-label" do %>
         画像 <span class="form-label__optional">任意</span>
       <% end %>
+
       <%= f.file_field :image,
           accept: "image/png,image/jpeg,image/jpg,image/webp",
           class: "form-file" %>
+
+      <div class="form-note-box">
+        <p class="form-note-box__limit">※ PNG / JPG / WEBP、5MB以下</p>
+        <p class="form-note">コメント: 個人情報や誹謗中傷は避けてください。</p>
+        <p class="form-note">画像: 設備の参考になるもののみ添付してください。</p>
+      </div>
     </div>
 
     <div class="review-form-actions">

--- a/app/views/toilet_reviews/new.html.erb
+++ b/app/views/toilet_reviews/new.html.erb
@@ -24,6 +24,15 @@
     <% end %>
 
     <div class="form-group">
+      <%= f.label :rating, "評価", class: "form-label" %>
+      <div class="form-help">1が低め、5が高評価です。</div>
+      <%= f.select :rating,
+          options_for_select(1..5, @review.rating),
+          { include_blank: "選択してください" },
+          class: "form-select" %>
+    </div>
+
+    <div class="form-group">
       <%= f.label :comment, class: "form-label" do %>
         コメント <span class="form-label__optional">任意</span>
       <% end %>

--- a/app/views/toilet_reviews/new.html.erb
+++ b/app/views/toilet_reviews/new.html.erb
@@ -24,30 +24,29 @@
     <% end %>
 
     <div class="form-group">
-      <%= f.label :rating, "評価", class: "form-label" %>
-      <div class="form-help">1が低め、5が高評価です。</div>
-      <%= f.select :rating,
-          options_for_select(1..5, @review.rating), 
-          { include_blank: "選択してください" },
-          class: "form-select" %>
-    </div>
-
-    <div class="form-group">
       <%= f.label :comment, class: "form-label" do %>
         コメント <span class="form-label__optional">任意</span>
       <% end %>
-      <div class="form-help">利用して気づいたことや、場所の分かりやすさなどを書けます。</div>
-      <%= f.text_area :comment, class: "form-textarea", rows: 5, placeholder: "例: 改札内の端の方にありました。比較的見つけやすかったです。" %>
+      <%= f.text_area :comment,
+          class: "form-textarea",
+          rows: 5,
+          placeholder: "例: 改札内の端の方にありました。比較的見つけやすかったです。" %>
     </div>
 
     <div class="form-group">
       <%= f.label :image, class: "form-label" do %>
         画像 <span class="form-label__optional">任意</span>
       <% end %>
-      <div class="form-help">PNG / JPG / WEBP、5MB以下の画像を添付できます。</div>
+
       <%= f.file_field :image,
           accept: "image/png,image/jpeg,image/jpg,image/webp",
           class: "form-file" %>
+
+      <div class="form-note-box">
+        <p class="form-note-box__limit">※ PNG / JPG / WEBP、5MB以下</p>
+        <p class="form-note">コメント: 個人情報や誹謗中傷は避けてください。</p>
+        <p class="form-note">画像: 設備の参考になるもののみ添付してください。</p>
+      </div>
     </div>
 
     <div class="review-form-actions">

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -56,4 +56,15 @@ RSpec.describe Review, type: :model do
     expect(review).not_to be_valid
     expect(review.errors[:comment]).to be_present
   end
+
+  it "is invalid when comment includes ng words" do
+    review = Review.new(user: user, toilet: toilet, rating: 3, comment: "このトイレはばか")
+    expect(review).not_to be_valid
+    expect(review.errors[:comment]).to include("に不適切な表現が含まれています")
+  end
+
+  it "is valid when comment does not include ng words" do
+    review = Review.new(user: user, toilet: toilet, rating: 3, comment: "清掃されていて使いやすかったです")
+    expect(review).to be_valid
+  end
 end


### PR DESCRIPTION
## 概要
レビューの不適切対策として、投稿フォームの注意文整理と簡易NGワードチェックを追加しました。


## 関連 issue
- closes #83 

## 変更内容
- レビュー投稿画面の注意文を調整
- レビュー編集画面の注意文を調整
- 画像欄の下に補足情報をまとめて表示するよう変更
- 補足文のスタイルを調整
- Review モデルに簡易NGワードチェックを追加
- Review モデルの spec を追加

## 確認項目
- [x] 投稿画面で注意文が適切に表示される
- [x] 編集画面で注意文が適切に表示される
- [x] 普通のコメントは保存できる
- [x] NGワードを含むコメントは保存できない
- [x] model spec が通る
- [x] 全体 rspec が通る

## 今回対象外
- NGワード辞書の拡張
- 表記ゆれ対応
- 通報機能
- 管理者によるレビュー管理機能
- 画像内容の自動判定