### PR TITLE
メール配信の為SMTP設定を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,13 +60,25 @@ Rails.application.configure do
 
   # ==================================
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # メール内URL生成用
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "example.com"),
+    protocol: "https"
+  }
 
-  # Set host to be used by links generated in mailer templates.
-  # 本番URLが決まったらここを変更
-  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS"),
+    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    domain: ENV.fetch("SMTP_DOMAIN", ENV.fetch("APP_HOST", "example.com")),
+    user_name: ENV.fetch("SMTP_USERNAME"),
+    password: ENV.fetch("SMTP_PASSWORD"),
+    authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain").to_sym,
+    enable_starttls_auto: ENV.fetch("SMTP_ENABLE_STARTTLS_AUTO", "true") == "true"
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## 概要
本番環境で新規登録時に 500 エラーが発生していたため、メール送信設定を修正しました。

## 背景
独自ドメイン反映後、新規登録時に確認メール送信処理で 500 エラーが発生していました。
Render のログを確認したところ、SMTP 設定が本番環境で反映されておらず、`localhost:25` へ接続しようとして失敗していました。

## 変更内容
- `config/environments/production.rb` に本番用 Action Mailer の SMTP 設定を追加
- `APP_HOST` を独自ドメイン利用前提で使用するよう整理
- Resend 利用を前提とした SMTP 環境変数に対応
- 本番環境で不足していた `SMTP_USERNAME` を追加する前提で整理

## 確認項目
- [x] 独自ドメインでトップページが表示できる
- [x] 独自ドメインで検索画面に遷移できる
- [x] 新しい Postgres に接続できるよう `DATABASE_URL` を差し替え済み
- [x] `db:migrate` を build command に含めてデプロイ済み
- [ ] 新規登録時の確認メール送信が成功すること
- [ ] 新規登録後に確認メールを受信できること
- [ ] 確認メールのリンクから認証完了できること

## 今回対象外
- トイレデータの本番投入方法の見直し
- 既存ユーザー重複時のエラーハンドリング改善
- 本番画像保存の永続化対応

## 関連
- 本番環境の新規登録 500 エラー修正