### PR TITLE
本リリース時点の新規登録時のメール確認機能をオミット

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
+  allow_unauthenticated_access only: %i[new create]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new
@@ -9,15 +9,10 @@ class SessionsController < ApplicationController
     user = User.authenticate_by(params.permit(:email_address, :password))
 
     if user
-      unless user.email_confirmed?
-        redirect_to new_session_path, alert: "メール確認が完了していません。確認メールをご確認ください。"
-        return
-      end
-
       start_new_session_for user
       redirect_to after_authentication_url
     else
-      redirect_to new_session_path, alert: "Try another email address or password."
+      redirect_to new_session_path, alert: "メールアドレスまたはパスワードをご確認ください。"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,12 +9,12 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      Rails.logger.info("[signup] user_id=#{@user.id} email=#{@user.email_address} token=#{@user.email_confirmation_token.inspect}")
+      @user.update_column(:email_confirmed_at, Time.current)
+      start_new_session_for(@user)
 
-      UserMailer.email_confirmation(@user).deliver_now
-
-      redirect_to new_session_path, notice: "確認メールを送信しました。メール内リンクから確認してください。"
+      redirect_to after_authentication_url, notice: "ユーザー登録が完了しました。"
     else
+      flash.now[:alert] = "登録できませんでした。入力内容をご確認ください。"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   before_create :set_email_confirmation_token
 
+  validates :email_address, presence: true, uniqueness: true
   validates :display_name, length: { maximum: 30 }, allow_blank: true
 
   def email_confirmed?

--- a/spec/requests/auth_sessions_spec.rb
+++ b/spec/requests/auth_sessions_spec.rb
@@ -3,9 +3,15 @@ require "rails_helper"
 RSpec.describe "AuthSessions", type: :request do
   describe "POST /session" do
     it "ユーザーはログインできる" do
+      user = User.create!(
+        email_address: "confirmed@example.com",
+        password: "password123",
+        password_confirmation: "password123"
+      )
+
       post session_path, params: {
         email_address: user.email_address,
-        password: "password"
+        password: "password123"
       }
 
       expect(response).to redirect_to(root_path)

--- a/spec/requests/auth_sessions_spec.rb
+++ b/spec/requests/auth_sessions_spec.rb
@@ -2,37 +2,13 @@ require "rails_helper"
 
 RSpec.describe "AuthSessions", type: :request do
   describe "POST /session" do
-    it "未確認ユーザーはログインできない（/session/newへ戻る）" do
-      user = User.create!(
-        email_address: "unconfirmed@example.com",
-        password: "password123",
-        password_confirmation: "password123"
-        # email_confirmed_at は nil のまま
-      )
-
+    it "ユーザーはログインできる" do
       post session_path, params: {
         email_address: user.email_address,
-        password: "password123"
+        password: "password"
       }
 
-      expect(response).to redirect_to(new_session_path)
-    end
-
-    it "確認済みユーザーはログインできる（after_authentication_urlへリダイレクト）" do
-      user = User.create!(
-        email_address: "confirmed@example.com",
-        password: "password123",
-        password_confirmation: "password123",
-        email_confirmed_at: Time.current
-      )
-
-      post session_path, params: {
-        email_address: user.email_address,
-        password: "password123"
-      }
-
-      expect(response).to have_http_status(:found) # 302
-      # ルートが固定でないなら「302になった」までで十分強いです
+      expect(response).to redirect_to(root_path)
     end
   end
 end

--- a/spec/requests/auth_signup_spec.rb
+++ b/spec/requests/auth_signup_spec.rb
@@ -2,14 +2,17 @@ require "rails_helper"
 
 RSpec.describe "Signup", type: :request do
   it "ユーザー登録できる（登録後にログインしてトップへ遷移する）" do
-    post signup_path, params: {
-      user: {
-        email_address: "test@example.com",
-        password: "password",
-        password_confirmation: "password"
+    expect {
+      post "/signup", params: {
+        user: {
+          email_address: "test-#{SecureRandom.hex(8)}@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        }
       }
-    }
+    }.to change(User, :count).by(1)
 
+    expect(response).to have_http_status(:found)
     expect(response).to redirect_to(root_path)
   end
 end

--- a/spec/requests/auth_signup_spec.rb
+++ b/spec/requests/auth_signup_spec.rb
@@ -1,23 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Signup", type: :request do
-  it "サインアップページが表示される" do
-    get "/signup"
-    expect(response).to have_http_status(:ok)
-  end
-
-  it "ユーザー登録できる（確認メール送信後、メール確認に進める）" do
-    expect {
-      post "/signup", params: {
-        user: {
-          email_address: "test-#{SecureRandom.hex(8)}@example.com",
-          password: "password123",
-          password_confirmation: "password123"
-        }
+  it "ユーザー登録できる（登録後にログインしてトップへ遷移する）" do
+    post signup_path, params: {
+      user: {
+        email_address: "test@example.com",
+        password: "password",
+        password_confirmation: "password"
       }
-    }.to change(User, :count).by(1)
+    }
 
-    expect(response).to have_http_status(:found)
-    expect(response).to redirect_to(new_session_path)
+    expect(response).to redirect_to(root_path)
   end
 end


### PR DESCRIPTION
## 概要
本リリース向け対応として、メール確認機能を一旦外し、新規登録後にそのまま利用できるようにしました。

## 背景
本番環境（Render Free）ではメール送信処理が安定せず、新規登録時に確認メール送信で 500 エラーが発生していました。
レビュアーからの本リリース要件を踏まえると、今回はメール確認機能そのものよりも、新規登録・ログインが正常に動作することを優先したほうが自然と判断しました。

## 変更内容
- 新規登録時の確認メール送信処理を一旦削除
- 新規登録後にそのままログイン状態にするよう変更
- ログイン時のメール確認チェックを削除
- `User` モデルにメールアドレスの一意性バリデーションを追加
- 重複メールアドレス登録時に 500 ではなく通常のフォームエラーとして扱えるよう整理

## 確認項目
- [ ] 未使用メールアドレスで新規登録できる
- [ ] 新規登録後にログイン状態で遷移できる
- [ ] ログアウトできる
- [ ] 既存ユーザーでログインできる
- [ ] 同一メールアドレスで登録したときに 500 ではなくエラー表示になる

## 今回対象外
- メール確認機能の本番対応
- Resend API 方式でのメール送信再実装
- SMTP / 確認メール送信機能の再導入

## 補足
メール確認機能は本リリースでは一旦外し、必要に応じて ポストリリースissue として再対応します。